### PR TITLE
refactor: handler以外全ての型定義をtypes/で管理する

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"puremania/cache"
+	"puremania/types"
 	"puremania/worker"
 	"time"
 )
@@ -10,23 +11,15 @@ const (
 	CacheTTL = 5 * time.Minute // Cache TTL
 )
 
-// IConfig は設定インターフェースです。
-type IConfig interface {
-	GetStorageDir() string
-	GetMountDirs() []string
-	GetMaxFileSize() int64
-	GetSpecificDirs() []string
-}
-
 // Handler はAPIハンドラーの依存関係を保持します。
 type Handler struct {
-	config     IConfig
-	cache      *cache.TTLCache
-	workerPool *worker.WorkerPool
+	config     *types.Config
+	cache      *types.TTLCache
+	workerPool *types.WorkerPool
 }
 
 // NewHandler は新しいHandlerを生成します。
-func NewHandler(config IConfig) *Handler {
+func NewHandler(config *types.Config) *Handler {
 	return &Handler{
 		config:     config,
 		cache:      cache.NewTTLCache(250*1024*1024, 15000), // 250MB, 15K items

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"puremania/handlers"
+	"puremania/types"
 	"strconv"
 	"strings"
 	"time"
@@ -15,39 +16,28 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// Config はアプリケーションの設定を保持します。
-type Config struct {
-	StorageDir      string
-	MountDirs       []string
-	MaxFileSize     int64
-	Port            int
-	ZipTimeout      int
-	MaxZipSize      int64
-	SpecificDirs    []string
-}
-
-func (c *Config) GetStorageDir() string {
+func GetStorageDir(c *types.Config) string {
 	return c.StorageDir
 }
 
-func (c *Config) GetMountDirs() []string {
+func GetMountDirs(c *types.Config) []string {
 	return c.MountDirs
 }
 
-func (c *Config) GetMaxFileSize() int64 {
+func GetMaxFileSize(c *types.Config) int64 {
 	return c.MaxFileSize
 }
 
-func (c *Config) GetSpecificDirs() []string {
+func GetSpecificDirs(c *types.Config) []string {
 	return c.SpecificDirs
 }
 
 // Load は.envファイルから設定を読み込みます。
-func LoadConfig() *Config {
+func LoadConfig() *types.Config {
 	_ = godotenv.Load() // .envファイルが見つからなくてもエラーにしない
 
 	// デフォルト値
-	config := &Config{
+	config := &types.Config{
 		StorageDir:      getEnv("STORAGE_DIR", "/home/"+os.Getenv("USER")),
 		MountDirs:       getEnvAsStringSlice("MOUNT_DIRS", []string{}),
 		MaxFileSize:     getEnvAsInt64("MAX_FILE_SIZE_MB", 10000),
@@ -87,7 +77,6 @@ func main() {
 
 	// ハンドラーを初期化
 	handler := handlers.NewHandler(cfg)
-
 
 	r := mux.NewRouter()
 

--- a/types/cache.go
+++ b/types/cache.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"sync"
+	"time"
+)
+
+// CacheEntry は統一キャッシュエントリ（TTL付き）です。
+type CacheEntry struct {
+	Data      interface{}
+	Timestamp time.Time
+	Size      int64
+	TTL       time.Duration
+}
+
+// IsExpired はエントリが期限切れかどうかを返します。
+func (c *CacheEntry) IsExpired() bool {
+	return time.Since(c.Timestamp) > c.TTL
+}
+
+// TTLCache は統一TTLキャッシュです。
+type TTLCache struct {
+	Mu       sync.RWMutex
+	Entries  map[string]*CacheEntry
+	Order    []string
+	MaxSize  int64
+	MaxItems int
+	CurSize  int64
+}

--- a/types/config.go
+++ b/types/config.go
@@ -1,0 +1,12 @@
+package types
+
+// Config はアプリケーションの設定を保持します。
+type Config struct {
+	StorageDir   string
+	MountDirs    []string
+	MaxFileSize  int64
+	Port         int
+	ZipTimeout   int
+	MaxZipSize   int64
+	SpecificDirs []string
+}

--- a/types/worker.go
+++ b/types/worker.go
@@ -1,0 +1,12 @@
+package types
+
+import "sync"
+
+// WorkerPool はCPU論理コア数ベースのワーカープールです。
+type WorkerPool struct {
+	Workers    int
+	TaskQueue  chan func()
+	ResultChan chan interface{}
+	Wg         sync.WaitGroup
+	Active     int64
+}


### PR DESCRIPTION
- handlerはそのまま
- 残りは全てtypes/配下に

```bash
thepassenger:[haturatu]:~/git/puremania$ grep -r "^type "
handlers/handlers.go:type Handler struct {
types/worker.go:type WorkerPool struct {
types/common.go:type APIResponse struct {
types/common.go:type SpecificDirInfo struct {
types/file.go:type FileInfo struct {
types/file.go:type CreateDirectoryRequest struct {
types/file.go:type SaveFileRequest struct {
types/file.go:type BatchPathsRequest struct {
types/file.go:type UploadResult struct {
types/config.go:type Config struct {
types/cache.go:type CacheEntry struct {
types/cache.go:type TTLCache struct {
```