### PR TITLE
fix: add missing video-view.css to remote template

### DIFF
--- a/index.html.remote
+++ b/index.html.remote
@@ -6,6 +6,7 @@
     <title>Pure Mania</title>
     <link rel="stylesheet" href="/static/css/style.css?=v0.0.3">
     <link rel="stylesheet" href="/static/css/masonry.css?=v0.0.2">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?=v0.0.1">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>


### PR DESCRIPTION
## Summary
- `index.html.remote` に `/static/css/components/video-view.css` の `<link>` を追加。
- このファイルは `static/css/components/` に存在するが、remote テンプレートには記載されていなかった。`jsload.sh remote` を実行すると配信される `static/index.html` がこのテンプレートで上書きされ、動画ビューが未スタイリングになる実害があった。

## Test plan
- `index.html.remote` と `static/index.html` の `<head>` の stylesheet リンクが一致していることを確認。