### PR TITLE
fix: change default container uid/gid from 10001 to 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
         procps \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --uid 10001 --home-dir /home/puremania --create-home --shell /usr/sbin/nologin puremania \
+RUN useradd --system --uid 1000 --home-dir /home/puremania --create-home --shell /usr/sbin/nologin puremania \
     && mkdir -p /app /data \
     && chown -R puremania:puremania /app /data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
     image: puremania:local
     container_name: puremania
-    user: "${PUREMANIA_UID:-10001}:${PUREMANIA_GID:-10001}"
+    user: "${PUREMANIA_UID:-1000}:${PUREMANIA_GID:-1000}"
     ports:
       - "${PUREMANIA_PORT:-8844}:8844"
     environment:


### PR DESCRIPTION
## Summary
- `docker-compose.yml` のデフォルト `PUREMANIA_UID`/`PUREMANIA_GID` を 10001 → 1000 に変更。
- `Dockerfile` の `useradd --uid` を 10001 → 1000 に変更。

## Test plan
- `grep -rn 10001 docker-compose.yml Dockerfile` で該当がなくなることを確認。