### PR TITLE
refactor: consolidate runtime env into docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,16 +31,6 @@ WORKDIR /app
 COPY --from=builder /out/puremania /app/puremania
 COPY static /app/static
 
-ENV STORAGE_DIR=/data \
-    HOME=/home/puremania \
-    MOUNT_DIRS= \
-    MAX_FILE_SIZE_MB=10000 \
-    PORT=8844 \
-    ZIP_TIMEOUT=300 \
-    MAX_ZIP_SIZE=1024 \
-    SPECIFIC_DIRS= \
-    ARIA2C=disable
-
 USER puremania
 
 EXPOSE 8844

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "${PUREMANIA_PORT:-8844}:8844"
     environment:
+      HOME: "${PUREMANIA_HOME:-/home/puremania}"
       STORAGE_DIR: /data
       PORT: 8844
       MAX_FILE_SIZE_MB: "${PUREMANIA_MAX_FILE_SIZE_MB:-10000}"


### PR DESCRIPTION
## Summary
- Dockerfile から `ENV` ブロックを削除し、実行時の環境変数を docker-compose.yml に一本化。
- Dockerfile は `USER puremania` 等の基本構成のみ保持。
- docker-compose の `environment` に `HOME` を追加し、他の変数と同様に `PUREMANIA_HOME` で上書き可能に（汎用化）。

## Test plan
- `grep -n "^ENV" Dockerfile` で ENV がなくなっていることを確認。
- `docker compose config` で env が解決されることを確認。