### PR TITLE
fix: harden resumable upload handling

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"hash/fnv"
 	"log/slog"
 	"puremania/cache"
 	"puremania/types"
@@ -20,8 +21,14 @@ type Handler struct {
 	cache       *types.TTLCache
 	workerPool  *types.WorkerPool
 	logger      *slog.Logger
-	uploadLocks sync.Map      // map[upload id]*sync.Mutex; serializes writes to one session
-	uploadGate  chan struct{} // bounds concurrent disk writes across sessions
+	uploadLocks [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
+	uploadGate  chan struct{}   // bounds concurrent disk writes across sessions
+}
+
+func (h *Handler) sessionMutex(id string) *sync.Mutex {
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(id))
+	return &h.uploadLocks[hash.Sum32()%uint32(len(h.uploadLocks))]
 }
 
 // NewHandler は新しいHandlerを生成

--- a/handlers/resumable_upload_handlers.go
+++ b/handlers/resumable_upload_handlers.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -17,7 +18,6 @@ import (
 	"puremania/cache"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -32,12 +32,14 @@ type uploadSession struct {
 	Completed     bool      `json:"completed"`
 	CreatedAt     time.Time `json:"createdAt"`
 	UpdatedAt     time.Time `json:"updatedAt"`
+	Fingerprint   string    `json:"fingerprint,omitempty"`
 }
 
 type createUploadRequest struct {
 	Path         string `json:"path"`
 	RelativePath string `json:"relativePath"`
 	Size         int64  `json:"size"`
+	Fingerprint  string `json:"fingerprint"`
 }
 
 func (h *Handler) uploadSessionDir() string {
@@ -86,11 +88,6 @@ func validUploadID(id string) bool {
 	}
 	_, err := hex.DecodeString(id)
 	return err == nil
-}
-
-func (h *Handler) sessionMutex(id string) *sync.Mutex {
-	lock, _ := h.uploadLocks.LoadOrStore(id, &sync.Mutex{})
-	return lock.(*sync.Mutex)
 }
 
 func (h *Handler) readUploadSession(id string) (*uploadSession, error) {
@@ -158,7 +155,15 @@ func (h *Handler) CreateUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := time.Now().UTC()
-	session := &uploadSession{ID: id, Destination: destination, RelativePath: relativePath, TotalBytes: req.Size, CreatedAt: now, UpdatedAt: now}
+	if req.Fingerprint == "" || len(req.Fingerprint) != sha256.Size*2 {
+		h.respondError(w, "Invalid upload fingerprint", http.StatusBadRequest)
+		return
+	}
+	if _, err := hex.DecodeString(req.Fingerprint); err != nil {
+		h.respondError(w, "Invalid upload fingerprint", http.StatusBadRequest)
+		return
+	}
+	session := &uploadSession{ID: id, Destination: destination, RelativePath: relativePath, TotalBytes: req.Size, CreatedAt: now, UpdatedAt: now, Fingerprint: req.Fingerprint}
 	// A zero-byte upload has no chunk request. Create its empty part now so
 	// completion follows the same atomic rename path as every other upload.
 	if req.Size == 0 {
@@ -178,7 +183,7 @@ func (h *Handler) CreateUpload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Location", location)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(map[string]any{"uploadId": id, "uploadURL": location, "uploadedBytes": int64(0)})
+	_ = json.NewEncoder(w).Encode(map[string]any{"uploadId": id, "uploadURL": location, "uploadedBytes": int64(0), "fingerprint": req.Fingerprint})
 }
 
 func parseContentRange(value string) (int64, int64, int64, error) {
@@ -189,13 +194,32 @@ func parseContentRange(value string) (int64, int64, int64, error) {
 	return start, end, total, nil
 }
 
-func writeUploadPosition(w http.ResponseWriter, session *uploadSession, status int) {
+func (h *Handler) resumeFingerprint(session *uploadSession) (string, int64) {
+	length := min(session.UploadedBytes, int64(1024*1024))
+	if length == 0 || session.Completed {
+		return "", 0
+	}
+	offset := session.UploadedBytes - length
+	part, err := os.Open(h.uploadTempPath(session.ID))
+	if err != nil {
+		return "", 0
+	}
+	defer part.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, io.NewSectionReader(part, offset, length)); err != nil {
+		return "", 0
+	}
+	return hex.EncodeToString(hash.Sum(nil)), offset
+}
+
+func (h *Handler) writeUploadPosition(w http.ResponseWriter, session *uploadSession, status int) {
 	if session.UploadedBytes > 0 {
 		w.Header().Set("Range", "bytes=0-"+strconv.FormatInt(session.UploadedBytes-1, 10))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]any{"uploadedBytes": session.UploadedBytes, "totalBytes": session.TotalBytes, "completed": session.Completed})
+	resumeFingerprint, resumeOffset := h.resumeFingerprint(session)
+	_ = json.NewEncoder(w).Encode(map[string]any{"uploadedBytes": session.UploadedBytes, "totalBytes": session.TotalBytes, "completed": session.Completed, "fingerprint": session.Fingerprint, "resumeFingerprint": resumeFingerprint, "resumeOffset": resumeOffset})
 }
 
 // UploadChunk accepts only the next contiguous range. A completely acknowledged
@@ -216,19 +240,23 @@ func (h *Handler) UploadChunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if session.Completed {
-		writeUploadPosition(w, session, http.StatusOK)
+		h.writeUploadPosition(w, session, http.StatusOK)
 		return
 	}
 	if end < session.UploadedBytes {
-		writeUploadPosition(w, session, http.StatusPermanentRedirect)
+		h.writeUploadPosition(w, session, http.StatusPermanentRedirect)
 		return
 	}
 	if start != session.UploadedBytes {
-		writeUploadPosition(w, session, http.StatusConflict)
+		h.writeUploadPosition(w, session, http.StatusConflict)
 		return
 	}
 	queueStart := time.Now()
-	h.uploadGate <- struct{}{}
+	select {
+	case h.uploadGate <- struct{}{}:
+	case <-r.Context().Done():
+		return
+	}
 	queueDelay := time.Since(queueStart)
 	defer func() { <-h.uploadGate }()
 	writeStart := time.Now()
@@ -238,6 +266,10 @@ func (h *Handler) UploadChunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer part.Close()
+	if err := part.Truncate(start); err != nil {
+		h.respondError(w, "Cannot reset upload data", http.StatusInternalServerError)
+		return
+	}
 	if _, err := part.Seek(start, io.SeekStart); err != nil {
 		h.respondError(w, "Cannot seek upload data", http.StatusInternalServerError)
 		return
@@ -246,9 +278,16 @@ func (h *Handler) UploadChunk(w http.ResponseWriter, r *http.Request) {
 	// Keep large sequential uploads from becoming valuable page-cache residents.
 	// This is advisory and does not alter the stream or the on-disk bytes.
 	prepareUploadRange(part, start, expected)
-	written, copyErr := io.CopyBuffer(part, io.LimitReader(r.Body, expected+1), make([]byte, 128*1024))
+	written, copyErr := io.CopyBuffer(part, io.LimitReader(r.Body, expected), make([]byte, 128*1024))
 	if copyErr != nil || written != expected {
+		_ = part.Truncate(start)
 		h.respondError(w, "Incomplete upload chunk", http.StatusBadRequest)
+		return
+	}
+	var extra [1]byte
+	if n, _ := r.Body.Read(extra[:]); n != 0 {
+		_ = part.Truncate(start)
+		h.respondError(w, "Upload chunk exceeds Content-Range", http.StatusBadRequest)
 		return
 	}
 	if err := part.Sync(); err != nil {
@@ -277,7 +316,7 @@ func (h *Handler) UploadChunk(w http.ResponseWriter, r *http.Request) {
 	if session.UploadedBytes == session.TotalBytes {
 		status = http.StatusOK
 	}
-	writeUploadPosition(w, session, status)
+	h.writeUploadPosition(w, session, status)
 }
 
 func (h *Handler) UploadStatus(w http.ResponseWriter, r *http.Request) {
@@ -290,7 +329,7 @@ func (h *Handler) UploadStatus(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Upload session not found", http.StatusNotFound)
 		return
 	}
-	writeUploadPosition(w, session, http.StatusOK)
+	h.writeUploadPosition(w, session, http.StatusOK)
 }
 
 func (h *Handler) CompleteUpload(w http.ResponseWriter, r *http.Request) {
@@ -320,13 +359,42 @@ func (h *Handler) CompleteUpload(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Cannot create destination directory", http.StatusInternalServerError)
 		return
 	}
-	if err := os.Rename(h.uploadTempPath(id), target); err != nil {
+	partPath := h.uploadTempPath(id)
+	if _, err := os.Stat(partPath); os.IsNotExist(err) {
+		if info, statErr := os.Stat(target); statErr == nil && info.Size() == session.TotalBytes {
+			session.Completed = true
+			if err := h.writeUploadSession(session); err != nil {
+				h.respondError(w, "Cannot persist completed upload", http.StatusInternalServerError)
+				return
+			}
+			cache.InvalidateByPrefix(h.cache, "list:"+filepath.Dir(h.convertToVirtualPath(target)))
+			cache.InvalidateByPrefix(h.cache, "search:")
+			h.respondSuccess(w, map[string]any{"path": h.convertToVirtualPath(target)})
+			return
+		}
+	}
+	part, err := os.OpenFile(partPath, os.O_WRONLY, 0600)
+	if err != nil {
+		h.respondError(w, "Cannot finalize upload", http.StatusInternalServerError)
+		return
+	}
+	if err := part.Truncate(session.TotalBytes); err == nil {
+		err = part.Sync()
+	}
+	closeErr := part.Close()
+	if err != nil || closeErr != nil {
+		h.respondError(w, "Cannot finalize upload", http.StatusInternalServerError)
+		return
+	}
+	if err := os.Rename(partPath, target); err != nil {
 		h.respondError(w, "Cannot finalize upload", http.StatusInternalServerError)
 		return
 	}
 	session.Completed = true
 	if err := h.writeUploadSession(session); err != nil {
 		h.logger.Error("Upload completed but session metadata update failed", "id", id, "error", err)
+		h.respondError(w, "Cannot persist completed upload", http.StatusInternalServerError)
+		return
 	}
 	cache.InvalidateByPrefix(h.cache, "list:"+filepath.Dir(h.convertToVirtualPath(target)))
 	cache.InvalidateByPrefix(h.cache, "search:")
@@ -344,6 +412,5 @@ func (h *Handler) AbortUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = os.Remove(h.uploadTempPath(id))
 	_ = os.Remove(h.uploadMetadataPath(id))
-	h.uploadLocks.Delete(id)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/handlers/resumable_upload_handlers_test.go
+++ b/handlers/resumable_upload_handlers_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"puremania/types"
+	"strings"
+	"testing"
+)
+
+func newUploadTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	return NewHandler(&types.Config{StorageDir: t.TempDir(), MaxFileSize: 1}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func createTestUpload(t *testing.T, h *Handler, relativePath string, size int64) (string, string) {
+	t.Helper()
+	body := strings.NewReader(`{"path":"/","relativePath":"` + relativePath + `","size":` + string(rune('0'+size)) + `,"fingerprint":"` + strings.Repeat("a", 64) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/files/upload-sessions", body)
+	res := httptest.NewRecorder()
+	h.CreateUpload(res, req)
+	if res.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var created struct{ UploadID, UploadURL string }
+	if err := json.Unmarshal(res.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	return created.UploadID, created.UploadURL
+}
+
+func TestUploadChunkOversizeRetryCannotLeaveTail(t *testing.T) {
+	h := newUploadTestHandler(t)
+	_, url := createTestUpload(t, h, "result.bin", 3)
+
+	oversize := httptest.NewRequest(http.MethodPut, url+"/chunks", bytes.NewReader([]byte("abcd")))
+	// Simulate chunked transfer: the server cannot reject the request based on
+	// Content-Length and must inspect the byte after the declared range.
+	oversize.ContentLength = -1
+	oversize.Header.Set("Content-Range", "bytes 0-2/3")
+	bad := httptest.NewRecorder()
+	h.UploadChunk(bad, oversize)
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("oversize status = %d", bad.Code)
+	}
+
+	retry := httptest.NewRequest(http.MethodPut, url+"/chunks", bytes.NewReader([]byte("abc")))
+	retry.Header.Set("Content-Range", "bytes 0-2/3")
+	ok := httptest.NewRecorder()
+	h.UploadChunk(ok, retry)
+	if ok.Code != http.StatusOK {
+		t.Fatalf("retry status = %d, body = %s", ok.Code, ok.Body.String())
+	}
+
+	complete := httptest.NewRecorder()
+	h.CompleteUpload(complete, httptest.NewRequest(http.MethodPost, url+"/complete", nil))
+	if complete.Code != http.StatusOK {
+		t.Fatalf("complete status = %d, body = %s", complete.Code, complete.Body.String())
+	}
+	content, err := os.ReadFile(filepath.Join(h.config.StorageDir, "result.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(content); got != "abc" {
+		t.Fatalf("completed content = %q, want %q", got, "abc")
+	}
+}
+
+func TestCompleteUploadRecoversAfterRenameBeforeMetadata(t *testing.T) {
+	h := newUploadTestHandler(t)
+	id, url := createTestUpload(t, h, "recovered.bin", 3)
+	session, err := h.readUploadSession(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.UploadedBytes = 3
+	if err := h.writeUploadSession(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(h.config.StorageDir, "recovered.bin"), []byte("abc"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	res := httptest.NewRecorder()
+	h.CompleteUpload(res, httptest.NewRequest(http.MethodPost, url+"/complete", nil))
+	if res.Code != http.StatusOK {
+		t.Fatalf("recovery status = %d, body = %s", res.Code, res.Body.String())
+	}
+	recovered, err := h.readUploadSession(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recovered.Completed {
+		t.Fatal("session was not repaired as completed")
+	}
+}

--- a/response_compression.go
+++ b/response_compression.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"compress/gzip"
+	"errors"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -22,6 +25,8 @@ func responseCompressionMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Identity and compressed representations both vary by this request header.
+		w.Header().Add("Vary", "Accept-Encoding")
 		encoding := selectContentEncoding(r.Header.Get("Accept-Encoding"))
 		if encoding == "" {
 			next.ServeHTTP(w, r)
@@ -44,6 +49,43 @@ type compressionResponseWriter struct {
 	started  bool
 	writer   io.Writer
 	closer   io.Closer
+}
+
+func (w *compressionResponseWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *compressionResponseWriter) Flush() {
+	if !w.started {
+		w.start()
+	}
+	if flusher, ok := w.writer.(interface{ Flush() error }); ok {
+		_ = flusher.Flush()
+	}
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *compressionResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("http.Hijacker is not supported")
+	}
+	return hijacker.Hijack()
+}
+
+func (w *compressionResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := w.ResponseWriter.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, opts)
+}
+
+func (w *compressionResponseWriter) ReadFrom(reader io.Reader) (int64, error) {
+	if !w.started {
+		w.start()
+	}
+	return io.Copy(w.writer, reader)
 }
 
 func (w *compressionResponseWriter) WriteHeader(status int) {
@@ -70,7 +112,6 @@ func (w *compressionResponseWriter) start() {
 		header := w.Header()
 		header.Del("Content-Length")
 		header.Set("Content-Encoding", w.encoding)
-		header.Add("Vary", "Accept-Encoding")
 		switch w.encoding {
 		case "br":
 			writer := brotli.NewWriterLevel(w.ResponseWriter, 4)

--- a/response_compression_test.go
+++ b/response_compression_test.go
@@ -83,3 +83,25 @@ func TestResponseCompressionSkipsRangesAndBinary(t *testing.T) {
 		}
 	}
 }
+
+func TestResponseCompressionVaryAndFlushForIdentityResponse(t *testing.T) {
+	flushed := false
+	handler := responseCompressionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, ok := w.(http.Flusher); !ok {
+			t.Fatal("compression writer does not preserve http.Flusher")
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("stream"))
+		w.(http.Flusher).Flush()
+		flushed = true
+	}))
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/stream", nil))
+	if !flushed {
+		t.Fatal("handler did not flush")
+	}
+	if got := res.Header().Get("Vary"); got != "Accept-Encoding" {
+		t.Fatalf("Vary = %q, want Accept-Encoding", got)
+	}
+}

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -150,16 +150,18 @@ export class Uploader {
             const request = this.resumeRequest;
             this.resumeRequest = null;
             destination = request.destination;
-            let matchesRequestedFile = false;
+            const requestedFiles = [];
             for (let index = 0; index < files.length; index++) {
-                if (request.keys.has(this.fileKey(files[index], destination))) { matchesRequestedFile = true; break; }
+                if (request.keys.has(this.fileKey(files[index], destination))) requestedFiles.push(files[index]);
                 if (index > 0 && index % PREPARE_BATCH_SIZE === 0) await yieldToBrowser();
             }
-            if (!matchesRequestedFile) {
+            if (requestedFiles.length !== request.keys.size) {
                 this.app.ui.showToast('Resume upload', 'Choose the original file or folder to resume this upload.', 'warning');
                 return;
             }
-            await this.discardWrongRouteDuplicates(files, destination);
+            await this.discardWrongRouteDuplicates(requestedFiles, destination);
+            await this.handleFileUpload(requestedFiles, destination);
+            return;
         }
         await this.handleFileUpload(files, destination);
     }
@@ -191,6 +193,24 @@ export class Uploader {
     fileKey(item, destination) {
         const { file, relativePath } = item;
         return `${destination}|${relativePath}|${file.size}|${file.lastModified}`;
+    }
+
+    async fileFingerprint(file) {
+        const sample = 1024 * 1024;
+        const first = await file.slice(0, sample).arrayBuffer();
+        const last = await file.slice(Math.max(0, file.size - sample)).arrayBuffer();
+        const bytes = new Uint8Array(first.byteLength + last.byteLength + 8);
+        bytes.set(new Uint8Array(first));
+        bytes.set(new Uint8Array(last), first.byteLength);
+        new DataView(bytes.buffer).setFloat64(bytes.length - 8, file.size);
+        const digest = await crypto.subtle.digest('SHA-256', bytes);
+        return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+    }
+
+    async fileRangeFingerprint(file, offset, length) {
+        const bytes = await file.slice(offset, offset + length).arrayBuffer();
+        const digest = await crypto.subtle.digest('SHA-256', bytes);
+        return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
     }
 
     async createUploadItems(fileList) {
@@ -282,12 +302,15 @@ export class Uploader {
 
     async getOrCreateRemoteSession(item, destination, session) {
         const key = this.fileKey(item, destination);
+        const fingerprint = await this.fileFingerprint(item.file);
         let saved;
         try { saved = await this.store.get(key); } catch (error) { console.warn('IndexedDB unavailable; upload cannot survive reload', error); }
         if (saved) {
             try {
                 const status = await this.apiJSON(saved.url, { signal: session.signal });
-                if (!status.completed && status.totalBytes === item.file.size) return { key, ...saved, uploadedBytes: status.uploadedBytes };
+                const resumeMatches = !status.resumeFingerprint ||
+                    status.resumeFingerprint === await this.fileRangeFingerprint(item.file, status.resumeOffset, status.uploadedBytes - status.resumeOffset);
+                if (!status.completed && status.totalBytes === item.file.size && status.fingerprint === fingerprint && resumeMatches) return { key, ...saved, uploadedBytes: status.uploadedBytes };
                 if (status.completed) await this.store.remove(key);
             } catch (error) {
                 if (this.isAbortError(error)) throw error;
@@ -296,9 +319,9 @@ export class Uploader {
         }
         const created = await this.apiJSON('/api/files/upload-sessions', {
             method: 'POST', signal: session.signal,
-            body: JSON.stringify({ path: destination, relativePath: item.relativePath, size: item.file.size })
+            body: JSON.stringify({ path: destination, relativePath: item.relativePath, size: item.file.size, fingerprint })
         });
-        const record = { key, id: created.uploadId, url: created.uploadURL, destination, relativePath: item.relativePath, size: item.file.size, updatedAt: Date.now() };
+        const record = { key, id: created.uploadId, url: created.uploadURL, destination, relativePath: item.relativePath, size: item.file.size, fingerprint, updatedAt: Date.now() };
         try { await this.store.put(record); this.notifyJobsChanged(); } catch (_) { /* upload itself must still work */ }
         return { ...record, uploadedBytes: created.uploadedBytes || 0 };
     }


### PR DESCRIPTION
## Summary
- prevent oversized chunks and failed retries from leaving stale bytes
- use bounded striped session locks and cancel waits when clients disconnect
- verify file fingerprints before resume, restrict selected resume uploads, and recover rename-before-metadata completion
- preserve compression ResponseWriter capabilities and set Vary for identity responses

## Tests
- go test ./...
- node --check static/js/uploader.js
- git diff --check