### PR TITLE
fix: harden file operations and background work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Run build script
         run: bash build.sh
 
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run go vet
+        run: go vet ./...
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"container/list"
 	"puremania/types"
 	"strings"
 	"time"
@@ -10,7 +11,8 @@ import (
 func NewTTLCache(maxSize int64, maxItems int) *types.TTLCache {
 	cache := &types.TTLCache{
 		Entries:  make(map[string]*types.CacheEntry),
-		Order:    make([]string, 0, maxItems),
+		Order:    list.New(),
+		Nodes:    make(map[string]*list.Element),
 		MaxSize:  maxSize,
 		MaxItems: maxItems,
 	}
@@ -50,7 +52,9 @@ func Get(c *types.TTLCache, key string) (interface{}, bool) {
 	if !exists || entry.IsExpired() {
 		if exists {
 			c.Mu.Lock()
-			evict(c, key)
+			if c.Entries[key] == entry && entry.IsExpired() {
+				evict(c, key)
+			}
 			c.Mu.Unlock()
 		}
 		return nil, false
@@ -70,14 +74,14 @@ func Set(c *types.TTLCache, key string, data interface{}, size int64, ttl time.D
 
 	if existing, exists := c.Entries[key]; exists {
 		c.CurSize -= existing.Size
-		removeFromOrder(c, key)
+		evict(c, key)
 	}
 
 	for c.CurSize+size > c.MaxSize || len(c.Entries) >= c.MaxItems {
-		if len(c.Order) == 0 {
+		if c.Order.Len() == 0 {
 			break
 		}
-		oldest := c.Order[len(c.Order)-1]
+		oldest := c.Order.Back().Value.(string)
 		evict(c, oldest)
 	}
 
@@ -87,25 +91,20 @@ func Set(c *types.TTLCache, key string, data interface{}, size int64, ttl time.D
 		Size:      size,
 		TTL:       ttl,
 	}
-	c.Order = append([]string{key}, c.Order...)
+	c.Nodes[key] = c.Order.PushFront(key)
 	c.CurSize += size
 }
 
 func moveToFront(c *types.TTLCache, key string) {
-	for i, k := range c.Order {
-		if k == key {
-			c.Order = append([]string{key}, append(c.Order[:i], c.Order[i+1:]...)...)
-			break
-		}
+	if node := c.Nodes[key]; node != nil {
+		c.Order.MoveToFront(node)
 	}
 }
 
 func removeFromOrder(c *types.TTLCache, key string) {
-	for i, k := range c.Order {
-		if k == key {
-			c.Order = append(c.Order[:i], c.Order[i+1:]...)
-			break
-		}
+	if node := c.Nodes[key]; node != nil {
+		c.Order.Remove(node)
+		delete(c.Nodes, key)
 	}
 }
 

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -68,9 +68,18 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid path: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	if h.isProtectedRoot(fullPath) {
+		h.respondError(w, "Cannot upload directly to a protected root", http.StatusBadRequest)
+		return
+	}
+	info, err := os.Stat(fullPath)
+	if err != nil || info.IsDir() {
+		h.respondError(w, "Cannot inspect video", http.StatusBadRequest)
+		return
+	}
 
-	// generate thumbnail filename based on SHA256 hash of the path
-	hash := sha256.Sum256([]byte(path))
+	// Include versioned file metadata so replacing a video cannot reuse stale art.
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%s:%d:%d", path, info.Size(), info.ModTime().UnixNano())))
 	thumbnailFilename := hex.EncodeToString(hash[:]) + ".jpg"
 	thumbnailPath := filepath.Join(thumbnailDir, thumbnailFilename)
 
@@ -82,7 +91,19 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 
 	// generate thumbnail
 	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
-		return h.generateThumbnail(fullPath, thumbnailPath)
+		tmp, err := os.CreateTemp(thumbnailDir, ".thumbnail-*.jpg")
+		if err != nil {
+			return err
+		}
+		tmpPath := tmp.Name()
+		if err := tmp.Close(); err != nil {
+			return err
+		}
+		defer os.Remove(tmpPath)
+		if err := h.generateThumbnail(fullPath, tmpPath); err != nil {
+			return err
+		}
+		return os.Rename(tmpPath, thumbnailPath)
 	})
 
 	result := <-resultChan
@@ -123,11 +144,30 @@ func (h *Handler) ExtractFile(w http.ResponseWriter, r *http.Request) {
 
 	// 出力先ディレクトリを決定 (例: archive.zip -> archive/)
 	destPath := strings.TrimSuffix(sourcePath, filepath.Ext(sourcePath))
+	if h.isProtectedRoot(destPath) {
+		h.respondError(w, "Cannot extract over a protected root", http.StatusBadRequest)
+		return
+	}
+	if _, err := os.Lstat(destPath); err == nil {
+		h.respondError(w, "Extraction destination already exists", http.StatusConflict)
+		return
+	} else if !os.IsNotExist(err) {
+		h.respondError(w, "Cannot inspect extraction destination", http.StatusInternalServerError)
+		return
+	}
 
 	// 並列処理で解凍
 	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // 30分タイムアウト
 		defer cancel()
+		tempPath, err := os.MkdirTemp(filepath.Dir(destPath), ".puremania-extract-*")
+		if err != nil {
+			return fmt.Errorf("cannot create extraction staging directory: %w", err)
+		}
+		defer os.RemoveAll(tempPath)
+		var extractedBytes int64
+		var extractedFiles int
+		maxBytes := h.config.MaxZipSize << 20
 
 		source, err := os.Open(sourcePath)
 		if err != nil {
@@ -145,7 +185,14 @@ func (h *Handler) ExtractFile(w http.ResponseWriter, r *http.Request) {
 		}
 
 		handler := func(ctx context.Context, f archives.FileInfo) error {
-			dest, err := secureJoin(destPath, f.NameInArchive)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			extractedFiles++
+			if extractedFiles > 10000 {
+				return fmt.Errorf("archive has too many files")
+			}
+			dest, err := secureJoin(tempPath, f.NameInArchive)
 			if err != nil {
 				return fmt.Errorf("unsafe file path in archive: %s", f.NameInArchive)
 			}
@@ -168,7 +215,7 @@ func (h *Handler) ExtractFile(w http.ResponseWriter, r *http.Request) {
 				}
 			}()
 
-			createdFile, err := os.Create(dest)
+			createdFile, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, f.Mode())
 			if err != nil {
 				return fmt.Errorf("could not create destination file: %w", err)
 			}
@@ -178,7 +225,11 @@ func (h *Handler) ExtractFile(w http.ResponseWriter, r *http.Request) {
 				}
 			}()
 
-			_, err = io.Copy(createdFile, file)
+			written, err := io.Copy(createdFile, io.LimitReader(file, maxBytes-extractedBytes+1))
+			extractedBytes += written
+			if extractedBytes > maxBytes {
+				return fmt.Errorf("archive exceeds extraction size limit")
+			}
 			return err
 		}
 
@@ -198,12 +249,11 @@ func (h *Handler) ExtractFile(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err != nil {
-			if err := os.RemoveAll(destPath); err != nil {
-				h.logger.Error("Failed to remove destination path after extraction error", "path", destPath, "error", err)
-			}
 			return fmt.Errorf("extraction failed: %w", err)
 		}
-
+		if err := os.Rename(tempPath, destPath); err != nil {
+			return fmt.Errorf("cannot publish extraction: %w", err)
+		}
 		return nil
 	})
 
@@ -510,32 +560,46 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// ファイル作成
-			dst, err := os.Create(targetPath)
+			if h.isProtectedRoot(targetPath) {
+				resultChan <- types.UploadResult{Path: relativePath, Success: false}
+				return
+			}
+			// Write to a sibling first so an interrupted legacy upload cannot
+			// truncate or remove an existing destination.
+			dst, err := os.CreateTemp(targetDir, ".puremania-uploading-*")
 			if err != nil {
 				h.logger.Error("Failed to create destination file", "path", targetPath, "error", err)
 				resultChan <- types.UploadResult{Path: relativePath, Success: false}
 				return
 			}
-			defer func() {
-				if err := dst.Close(); err != nil {
-					h.logger.Error("Failed to close destination file for upload", "path", targetPath, "error", err)
-				}
-			}()
+			tmpPath := dst.Name()
 
 			// The legacy multipart endpoint is retained for compatibility, but it
 			// must never materialize even a "small" file with io.ReadAll. The
 			// resumable endpoint is used by the UI; this preserves the same bounded
 			// memory property for older API consumers.
 			_, saveErr := io.CopyBuffer(dst, file, make([]byte, getOptimalBufferSize(fileHeader.Size)))
+			if saveErr == nil {
+				saveErr = dst.Sync()
+			}
 
 			// エラーチェック
 			if saveErr != nil {
+				_ = dst.Close()
 				h.logger.Error("Failed to save uploaded file", "path", targetPath, "error", saveErr)
-				// エラー時は作成したファイルを削除
-				if err := os.Remove(targetPath); err != nil {
+				if err := os.Remove(tmpPath); err != nil {
 					h.logger.Error("Failed to remove partially uploaded file", "path", targetPath, "error", err)
 				}
+				resultChan <- types.UploadResult{Path: relativePath, Success: false}
+				return
+			}
+			if err := dst.Close(); err != nil {
+				_ = os.Remove(tmpPath)
+				resultChan <- types.UploadResult{Path: relativePath, Success: false}
+				return
+			}
+			if err := os.Rename(tmpPath, targetPath); err != nil {
+				_ = os.Remove(tmpPath)
 				resultChan <- types.UploadResult{Path: relativePath, Success: false}
 				return
 			}
@@ -730,36 +794,51 @@ func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 	// io.Pipeでストリーミング
 	pr, pw := io.Pipe()
 
-	// 並列処理でzip作成
+	// zip.Writer is inherently serial. Keeping this work out of the shared
+	// worker pool avoids parent tasks waiting on child tasks in that same pool.
 	go func() {
-		defer func() {
-			if err := pw.Close(); err != nil {
-				h.logger.Error("Failed to close pipe writer", "error", err)
-			}
-		}()
-		h.createZipArchive(pw, req.Paths)
+		ctx, cancel := context.WithTimeout(r.Context(), time.Duration(h.config.ZipTimeout)*time.Second)
+		defer cancel()
+		if err := h.createZipArchive(ctx, pw, req.Paths); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
 	}()
 
 	// ストリーミング出力
 	_, _ = io.Copy(w, pr)
 }
 
-func (h *Handler) createZipArchive(w io.Writer, paths []string) {
-	zipWriter := zip.NewWriter(w)
-	defer func() {
-		if err := zipWriter.Close(); err != nil {
-			h.logger.Error("Failed to close zip writer", "error", err)
-		}
-	}()
+type maxBytesWriter struct {
+	w         io.Writer
+	remaining int64
+}
+
+func (w *maxBytesWriter) Write(p []byte) (int, error) {
+	if int64(len(p)) > w.remaining {
+		return 0, fmt.Errorf("zip output exceeds configured size limit")
+	}
+	n, err := w.w.Write(p)
+	w.remaining -= int64(n)
+	return n, err
+}
+
+func (h *Handler) createZipArchive(ctx context.Context, w io.Writer, paths []string) error {
+	zipWriter := zip.NewWriter(&maxBytesWriter{w: w, remaining: h.config.MaxZipSize << 20})
 
 	var successfulFiles, failedFiles int64
+	var inputBytes int64
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
 	// 並列処理でファイルをZIPに追加
 	for _, userPath := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		wg.Add(1)
-		worker.Submit(h.workerPool, func() {
+		func() {
 			defer wg.Done()
 
 			fullPath, err := h.convertToPhysicalPath(userPath)
@@ -780,6 +859,11 @@ func (h *Handler) createZipArchive(w io.Writer, paths []string) {
 				// ディレクトリの場合は並列WalkDir
 				h.addDirectoryToZip(zipWriter, fullPath, &successfulFiles, &failedFiles, &mu)
 			} else {
+				inputBytes += fileInfo.Size()
+				if inputBytes > h.config.MaxZipSize<<20 {
+					atomic.AddInt64(&failedFiles, 1)
+					return
+				}
 				// 単一ファイルの処理
 				if h.addFileToZip(zipWriter, fullPath, filepath.Base(userPath), &mu) {
 					atomic.AddInt64(&successfulFiles, 1)
@@ -787,10 +871,17 @@ func (h *Handler) createZipArchive(w io.Writer, paths []string) {
 					atomic.AddInt64(&failedFiles, 1)
 				}
 			}
-		})
+		}()
 	}
 
 	wg.Wait()
+	if failedFiles > 0 {
+		return fmt.Errorf("failed to add %d file(s) to zip", failedFiles)
+	}
+	if err := zipWriter.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *Handler) addDirectoryToZip(zipWriter *zip.Writer, dirPath string, successfulFiles, failedFiles *int64, mu *sync.Mutex) {
@@ -836,16 +927,12 @@ func (h *Handler) addDirectoryToZip(zipWriter *zip.Writer, dirPath string, succe
 			return nil
 		}
 
-		// 並列処理でファイルを追加
-		wg.Add(1)
-		worker.Submit(h.workerPool, func() {
-			defer wg.Done()
-			if h.addFileToZip(zipWriter, filePath, relPath, mu) {
-				atomic.AddInt64(successfulFiles, 1)
-			} else {
-				atomic.AddInt64(failedFiles, 1)
-			}
-		})
+		// zip.Writer must be written serially; addFileToZip already holds mu.
+		if h.addFileToZip(zipWriter, filePath, relPath, mu) {
+			atomic.AddInt64(successfulFiles, 1)
+		} else {
+			atomic.AddInt64(failedFiles, 1)
+		}
 
 		return nil
 	})
@@ -907,12 +994,14 @@ func (h *Handler) addFileToZip(zipWriter *zip.Writer, filePath, zipPath string, 
 
 func (h *Handler) SaveFile(w http.ResponseWriter, r *http.Request) {
 	var req types.SaveFileRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	r.Body = http.MaxBytesReader(w, r.Body, 11<<20)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
 		h.logger.Error("Failed to decode request body for saving file", "error", err)
 		h.respondError(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-
 	if req.Path == "" {
 		h.respondError(w, "Path required", http.StatusBadRequest)
 		return
@@ -924,10 +1013,14 @@ func (h *Handler) SaveFile(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid path: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	if h.isProtectedRoot(fullPath) {
+		h.respondError(w, "Cannot overwrite a protected root", http.StatusBadRequest)
+		return
+	}
 
 	// 並列処理でファイル保存
 	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
-		err := os.WriteFile(fullPath, []byte(req.Content), 0644)
+		err := atomicWriteFile(fullPath, []byte(req.Content), 0644)
 		return err
 	})
 
@@ -968,6 +1061,12 @@ func (h *Handler) DeleteMultipleFiles(w http.ResponseWriter, r *http.Request) {
 				h.logger.Error("Invalid path for deletion", "path", path, "error", err)
 				mu.Lock()
 				errors = append(errors, fmt.Sprintf("Invalid path %s: %v", path, err))
+				mu.Unlock()
+				return
+			}
+			if h.isProtectedRoot(fullPath) {
+				mu.Lock()
+				errors = append(errors, fmt.Sprintf("Cannot delete protected root %s", path))
 				mu.Unlock()
 				return
 			}
@@ -1012,8 +1111,12 @@ func (h *Handler) CreateDirectory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newDirPath := filepath.Join(parentPath, req.Name)
 	if strings.Contains(req.Name, "..") {
+		h.respondError(w, "Invalid directory name", http.StatusBadRequest)
+		return
+	}
+	newDirPath, err := secureJoin(parentPath, req.Name)
+	if err != nil {
 		h.respondError(w, "Invalid directory name", http.StatusBadRequest)
 		return
 	}
@@ -1061,11 +1164,19 @@ func (h *Handler) MoveFile(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid source path: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	if h.isProtectedRoot(sourceFullPath) {
+		h.respondError(w, "Cannot move a protected root", http.StatusBadRequest)
+		return
+	}
 
 	targetFullPath, err := h.convertToPhysicalPath(req.TargetPath)
 	if err != nil {
 		h.logger.Error("Invalid target path for moving", "path", req.TargetPath, "error", err)
 		h.respondError(w, "Invalid target path: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if h.isProtectedRoot(targetFullPath) {
+		h.respondError(w, "Cannot overwrite a protected root", http.StatusBadRequest)
 		return
 	}
 
@@ -1128,9 +1239,17 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		req.Name += ".md"
 	}
 
-	newFilePath := filepath.Join(parentPath, req.Name)
 	if strings.Contains(req.Name, "..") {
 		h.respondError(w, "Invalid file name", http.StatusBadRequest)
+		return
+	}
+	newFilePath, err := secureJoin(parentPath, req.Name)
+	if err != nil {
+		h.respondError(w, "Invalid file name", http.StatusBadRequest)
+		return
+	}
+	if h.isProtectedRoot(newFilePath) {
+		h.respondError(w, "Cannot overwrite a protected root", http.StatusBadRequest)
 		return
 	}
 

--- a/handlers/resumable_upload_handlers_test.go
+++ b/handlers/resumable_upload_handlers_test.go
@@ -100,3 +100,24 @@ func TestCompleteUploadRecoversAfterRenameBeforeMetadata(t *testing.T) {
 		t.Fatal("session was not repaired as completed")
 	}
 }
+
+func TestProtectedRootCannotBeDeletedAndSymlinkEscapesAreRejected(t *testing.T) {
+	h := newUploadTestHandler(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(h.config.StorageDir, "outside")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.convertToPhysicalPath("/outside/secret"); err == nil {
+		t.Fatal("symlink path outside storage was accepted")
+	}
+
+	body := strings.NewReader(`{"paths":["/"]}`)
+	res := httptest.NewRecorder()
+	h.DeleteMultipleFiles(res, httptest.NewRequest(http.MethodPost, "/api/files/delete", body))
+	if res.Code < 400 {
+		t.Fatalf("delete root status = %d", res.Code)
+	}
+	if _, err := os.Stat(h.config.StorageDir); err != nil {
+		t.Fatalf("storage root was removed: %v", err)
+	}
+}

--- a/handlers/search_handlers.go
+++ b/handlers/search_handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 
 	"mime"
@@ -10,7 +11,6 @@ import (
 	"puremania/cache"
 	"puremania/types"
 	"puremania/utils"
-	"puremania/worker"
 	"regexp"
 	"sort"
 	"strings"
@@ -41,8 +41,18 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.MaxResults == 0 {
+	if req.MaxResults <= 0 || req.MaxResults > 10000 {
 		req.MaxResults = 1000
+	}
+	if req.UseRegex {
+		pattern := req.Term
+		if !req.CaseSensitive {
+			pattern = "(?i)" + pattern
+		}
+		if _, err := regexp.Compile(pattern); err != nil {
+			h.respondError(w, "Invalid regular expression", http.StatusBadRequest)
+			return
+		}
 	}
 
 	// 細かいキャッシュキーを生成
@@ -61,30 +71,28 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 並列処理で検索実行
-	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
-		return h.performSearch(req, basePath)
-	})
-
-	result := <-resultChan
-	if results, ok := result.([]types.FileInfo); ok {
+	results, searchErr := h.performSearch(r.Context(), req, basePath)
+	if searchErr == nil {
 		// 結果をキャッシュ（検索結果は短めのTTL）
 		cache.Set(h.cache, cacheKey, results, int64(len(results)*200), time.Minute*2)
 		h.respondSuccess(w, results)
 	} else {
-		h.logger.Error("Search failed to return results")
+		if searchErr == context.Canceled || searchErr == context.DeadlineExceeded {
+			return
+		}
+		h.logger.Error("Search failed", "error", searchErr)
 		h.respondError(w, "Search failed", http.StatusInternalServerError)
 	}
 }
 
-func (h *Handler) performSearch(req struct {
+func (h *Handler) performSearch(ctx context.Context, req struct {
 	Term          string `json:"term"`
 	Path          string `json:"path"`
 	Scope         string `json:"scope"`
 	UseRegex      bool   `json:"useRegex"`
 	CaseSensitive bool   `json:"caseSensitive"`
 	MaxResults    int    `json:"maxResults"`
-}, basePath string) []types.FileInfo {
+}, basePath string) ([]types.FileInfo, error) {
 	var searchFunc func(string) bool
 
 	if req.UseRegex {
@@ -97,7 +105,7 @@ func (h *Handler) performSearch(req struct {
 		}
 		if err != nil {
 			h.logger.Error("Invalid regex in search", "term", req.Term, "error", err)
-			return []types.FileInfo{}
+			return nil, err
 		}
 		searchFunc = func(name string) bool {
 			return regex.MatchString(name)
@@ -116,14 +124,14 @@ func (h *Handler) performSearch(req struct {
 	}
 
 	if req.Scope == "recursive" {
-		return h.searchRecursiveParallel(basePath, searchFunc, req.MaxResults)
+		return h.searchRecursiveParallel(ctx, basePath, searchFunc, req.MaxResults), nil
 	} else {
-		return h.searchCurrentParallel(basePath, searchFunc, req.MaxResults)
+		return h.searchCurrentParallel(ctx, basePath, searchFunc, req.MaxResults), nil
 	}
 }
 
 // searchCurrentParallel - 並列処理で現在ディレクトリ検索
-func (h *Handler) searchCurrentParallel(path string, matchFunc func(string) bool, maxResults int) []types.FileInfo {
+func (h *Handler) searchCurrentParallel(ctx context.Context, path string, matchFunc func(string) bool, maxResults int) []types.FileInfo {
 	var results []types.FileInfo
 	var mu sync.Mutex
 
@@ -137,12 +145,20 @@ func (h *Handler) searchCurrentParallel(path string, matchFunc func(string) bool
 	resultCount := int64(0)
 
 	for _, entry := range entries {
+		if ctx.Err() != nil {
+			break
+		}
 		if atomic.LoadInt64(&resultCount) >= int64(maxResults) {
 			break
 		}
 
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
 		wg.Add(1)
-		worker.Submit(h.workerPool, func() {
+		func() {
 			defer wg.Done()
 
 			if atomic.LoadInt64(&resultCount) >= int64(maxResults) {
@@ -187,7 +203,7 @@ func (h *Handler) searchCurrentParallel(path string, matchFunc func(string) bool
 				}
 				mu.Unlock()
 			}
-		})
+		}()
 	}
 
 	wg.Wait()
@@ -195,12 +211,17 @@ func (h *Handler) searchCurrentParallel(path string, matchFunc func(string) bool
 }
 
 // searchRecursiveParallel - 並列処理で再帰検索
-func (h *Handler) searchRecursiveParallel(path string, matchFunc func(string) bool, maxResults int) []types.FileInfo {
+func (h *Handler) searchRecursiveParallel(ctx context.Context, path string, matchFunc func(string) bool, maxResults int) []types.FileInfo {
 	var results []types.FileInfo
 	var mu sync.Mutex
 	resultCount := int64(0)
 
 	_ = filepath.WalkDir(path, func(filePath string, d os.DirEntry, err error) error {
+		select {
+		case <-ctx.Done():
+			return filepath.SkipAll
+		default:
+		}
 		if err != nil {
 			h.logger.Warn("Skipping path in recursive search due to error", "path", filePath, "error", err)
 			return nil // エラーをスキップして継続

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -136,14 +136,14 @@ func (h *Handler) generateDirectoryStateKey(path string) (string, error) {
 		return entries[i].Name() < entries[j].Name()
 	})
 
-	var stateBuilder strings.Builder
+	hash := md5.New()
 	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {
 			h.logger.Warn("Failed to get entry info for state key generation", "entry", entry.Name(), "error", err)
 			continue
 		}
-		fmt.Fprintf(&stateBuilder, "%s:%d:%d;", info.Name(), info.Size(), info.ModTime().UnixNano())
+		_, _ = fmt.Fprintf(hash, "%s:%d:%d;", info.Name(), info.Size(), info.ModTime().UnixNano())
 	}
 
 	// ルートディレクトリの場合、マウントポイントの情報もキーに含める
@@ -155,15 +155,14 @@ func (h *Handler) generateDirectoryStateKey(path string) (string, error) {
 
 		for _, mountDir := range sortedMounts {
 			if info, err := os.Stat(mountDir); err == nil {
-				fmt.Fprintf(&stateBuilder, "mount_%s:%d:%d;", info.Name(), info.Size(), info.ModTime().UnixNano())
+				_, _ = fmt.Fprintf(hash, "mount_%s:%d:%d;", info.Name(), info.Size(), info.ModTime().UnixNano())
 			} else if !os.IsNotExist(err) {
 				h.logger.Warn("Failed to stat mount dir for state key generation", "path", mountDir, "error", err)
 			}
 		}
 	}
 
-	hash := md5.Sum([]byte(stateBuilder.String()))
-	return hex.EncodeToString(hash[:]), nil
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // キャッシュ無効化メソッド
@@ -202,6 +201,10 @@ func (h *Handler) ensurePathInAllowedDirs(path string) (string, error) {
 		return "", fmt.Errorf("could not get absolute path: %w", err)
 	}
 	absPhysicalPath = filepath.Clean(absPhysicalPath)
+	resolvedPath, err := resolveExistingPath(absPhysicalPath)
+	if err != nil {
+		return "", err
+	}
 
 	allowedDirs := make([]string, 0, len(h.config.MountDirs)+1+len(h.config.SpecificDirs))
 	allowedDirs = append(allowedDirs, h.config.MountDirs...)
@@ -215,12 +218,60 @@ func (h *Handler) ensurePathInAllowedDirs(path string) (string, error) {
 			continue
 		}
 		absAllowedDir = filepath.Clean(absAllowedDir)
-		if isPathWithin(absAllowedDir, absPhysicalPath) {
-			return absPhysicalPath, nil
+		resolvedAllowedDir, err := resolveExistingPath(absAllowedDir)
+		if err != nil {
+			continue
+		}
+		if isPathWithin(resolvedAllowedDir, resolvedPath) {
+			return resolvedPath, nil
 		}
 	}
 
 	return "", fmt.Errorf("path is not in an allowed directory: %s", path)
+}
+
+// resolveExistingPath resolves every existing path component. This rejects a
+// path such as storage/link/file when link points outside an allowed root.
+func resolveExistingPath(path string) (string, error) {
+	path = filepath.Clean(path)
+	var missing []string
+	probe := path
+	for {
+		if _, err := os.Lstat(probe); err == nil {
+			resolved, err := filepath.EvalSymlinks(probe)
+			if err != nil {
+				return "", err
+			}
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return resolved, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return "", fmt.Errorf("no existing parent for %s", path)
+		}
+		missing = append(missing, filepath.Base(probe))
+		probe = parent
+	}
+}
+
+func (h *Handler) isProtectedRoot(path string) bool {
+	clean, err := resolveExistingPath(path)
+	if err != nil {
+		return false
+	}
+	roots := append([]string{h.config.StorageDir}, h.config.MountDirs...)
+	roots = append(roots, h.config.SpecificDirs...)
+	for _, root := range roots {
+		resolved, err := resolveExistingPath(root)
+		if err == nil && clean == filepath.Clean(resolved) {
+			return true
+		}
+	}
+	return false
 }
 
 func secureJoin(basePath, relPath string) (string, error) {
@@ -240,8 +291,49 @@ func secureJoin(basePath, relPath string) (string, error) {
 	if !isPathWithin(absBasePath, absJoinedPath) {
 		return "", fmt.Errorf("unsafe path: %s", relPath)
 	}
+	resolvedBase, err := resolveExistingPath(absBasePath)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := resolveExistingPath(absJoinedPath)
+	if err != nil {
+		return "", err
+	}
+	if !isPathWithin(resolvedBase, resolvedPath) {
+		return "", fmt.Errorf("unsafe symlink path: %s", relPath)
+	}
+	return resolvedPath, nil
+}
 
-	return absJoinedPath, nil
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".puremania-writing-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(perm); err == nil {
+		_, err = tmp.Write(data)
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }
 
 func isPathWithin(basePath, targetPath string) bool {

--- a/main.go
+++ b/main.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"puremania/handlers"
 	"puremania/types"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -205,14 +209,24 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Handler:      responseCompressionMiddleware(corsMiddleware(r)),
-		Addr:         fmt.Sprintf(":%d", cfg.Port),
-		WriteTimeout: 300 * time.Second,
-		ReadTimeout:  300 * time.Second,
-		IdleTimeout:  300 * time.Second,
+		Handler:           responseCompressionMiddleware(r),
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
-
-	logger.Error("Server stopped", "error", srv.ListenAndServe())
+	shutdownContext, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-shutdownContext.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			logger.Error("Graceful shutdown failed", "error", err)
+		}
+	}()
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("Server stopped", "error", err)
+	}
 }
 
 func staticCacheMiddleware(next http.Handler) http.Handler {
@@ -224,24 +238,6 @@ func staticCacheMiddleware(next http.Handler) http.Handler {
 			// Revalidate them so a switch never serves a previous version.
 			w.Header().Set("Cache-Control", "no-cache")
 		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Range, Content-Range, Content-Disposition, X-Requested-With")
-		w.Header().Set("Access-Control-Expose-Headers", "Content-Range, Content-Length, Range, Accept-Ranges, Content-Disposition, Upload-Queue-Delay, Upload-Write-Time, Upload-Recommend-Concurrency")
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Max-Age", "86400") // 24時間
-
-		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/types/cache.go
+++ b/types/cache.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"container/list"
 	"sync"
 	"time"
 )
@@ -22,7 +23,8 @@ func (c *CacheEntry) IsExpired() bool {
 type TTLCache struct {
 	Mu       sync.RWMutex
 	Entries  map[string]*CacheEntry
-	Order    []string
+	Order    *list.List
+	Nodes    map[string]*list.Element
 	MaxSize  int64
 	MaxItems int
 	CurSize  int64

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -34,8 +34,11 @@ func worker(p *types.WorkerPool) {
 	defer p.Wg.Done()
 	for task := range p.TaskQueue {
 		atomic.AddInt64(&p.Active, 1)
-		task()
-		atomic.AddInt64(&p.Active, -1)
+		func() {
+			defer atomic.AddInt64(&p.Active, -1)
+			defer func() { _ = recover() }()
+			task()
+		}()
 	}
 }
 


### PR DESCRIPTION
## Summary
- protect configured storage roots and reject symlink escapes
- use atomic writes for legacy uploads and file saves; stage archive extraction
- remove nested worker-pool submissions, enforce search cancellation and ZIP limits
- add graceful shutdown, safe transfer timeouts, cache LRU improvements, CORS removal, and CI tests

## Tests
- go test ./...
- go vet ./...
- node --check static/js/uploader.js
- git diff --check