### PR TITLE
fix: guard frontend navigation and upload state

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -6,6 +6,8 @@ export class ApiClient {
         this.app = app;
         this.directoryEtags = new Map();
         this.directoryCache = new Map();
+        this.directoryRequestId = 0;
+        this.directoryAbortController = null;
     }
 
     async postJson(url, payload) {
@@ -115,7 +117,7 @@ export class ApiClient {
         }
     }
 
-    async getFiles(path) {
+    async getFiles(path, signal) {
         try {
             const headers = {};
             const etag = this.directoryEtags.get(path);
@@ -123,7 +125,7 @@ export class ApiClient {
                 headers['If-None-Match'] = etag;
             }
 
-            const response = await fetch(buildApiUrl('/api/files', { path }), { headers });
+            const response = await fetch(buildApiUrl('/api/files', { path }), { headers, signal });
 
             if (response.status === 304) {
                 console.log(`Content for ${path} not modified. Using cache.`);
@@ -149,15 +151,21 @@ export class ApiClient {
                 throw new Error(result.message || 'API returned success:false');
             }
         } catch (error) {
+            if (error.name === 'AbortError') throw error;
             console.error(`Error in getFiles for path ${path}:`, error);
             return null;
         }
     }
 
     async loadFiles(path) {
+        const requestId = ++this.directoryRequestId;
+        this.directoryAbortController?.abort();
+        const controller = new AbortController();
+        this.directoryAbortController = controller;
         try {
             this.app.ui.showLoading();
-            const files = await this.getFiles(path);
+            const files = await this.getFiles(path, controller.signal);
+            if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
 
             if (files !== null) {
                 this.app.ui.displayFiles(files);
@@ -171,11 +179,13 @@ export class ApiClient {
                 this.app.router.updatePath(path);
             }
         } catch (error) {
+            if (error.name === 'AbortError') return;
+            if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
             this.notifyApiError('An unexpected error occurred while loading files.', { error, context: 'in loadFiles' });
             this.app.ui.displayFiles([]);
             this.app.router.updatePath(path);
         } finally {
-            this.app.ui.hideLoading();
+            if (requestId === this.directoryRequestId) this.app.ui.hideLoading();
         }
     }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -20,6 +20,7 @@ class FileManagerApp {
         this.config = {};
         this.directoryScrollPositions = new Map();
         this.renderedDirectoryPath = null;
+        this.editRequestId = 0;
         this.isPC = !/Mobi|Android/i.test(navigator.userAgent);
 
         // Initialize modules that don't depend on templates in their constructor
@@ -131,8 +132,9 @@ class FileManagerApp {
     }
 
     async editFile(path) {
+        const requestId = ++this.editRequestId;
         const content = await this.api.fetchFileContent(path);
-        if (content !== null) {
+        if (requestId === this.editRequestId && content !== null) {
             this.editor.open(path, content);
         }
     }

--- a/static/js/aria2c-page.js
+++ b/static/js/aria2c-page.js
@@ -8,6 +8,8 @@ export class Aria2cPageHandler {
         this.lastStatus = null;
         this.previousPath = '/'; // Store the path before entering this page
         this.torrentsToCancel = new Set(); // Track torrents scheduled for cancellation
+        this.polling = false;
+        this.pollTimer = null;
     }
 
     init() {
@@ -25,7 +27,6 @@ export class Aria2cPageHandler {
         this.isInAria2cMode = true;
         this.fileManager.ui.showLoading();
         this.loadAria2cStatus();
-        this.updateInterval = setInterval(() => this.loadAria2cStatus(), 2000); // Update every 2 seconds
         
         const breadcrumbs = document.querySelector('.breadcrumbs');
         if (breadcrumbs) breadcrumbs.style.display = 'none';
@@ -34,7 +35,7 @@ export class Aria2cPageHandler {
     exitAria2cMode(navigate = true) {
         if (!this.isInAria2cMode) return;
         this.isInAria2cMode = false;
-        clearInterval(this.updateInterval);
+        clearTimeout(this.pollTimer);
         this.updateInterval = null;
         this.lastStatus = null;
 
@@ -45,18 +46,22 @@ export class Aria2cPageHandler {
     }
 
     async loadAria2cStatus() {
+        if (!this.isInAria2cMode || this.polling) return;
+        this.polling = true;
         try {
             const status = await this.fileManager.api.getAria2cStatus();
             if (status) {
                 this.lastStatus = status;
-                this.render(status);
+                if (this.isInAria2cMode && this.fileManager.router.getCurrentPath() === '/system/aria2c') this.render(status);
             } else {
                 // API method failed and should have shown a toast.
                 // Stop polling.
-                clearInterval(this.updateInterval);
+                this.isInAria2cMode = false;
             }
         } finally {
+            this.polling = false;
             this.fileManager.ui.hideLoading();
+            if (this.isInAria2cMode) this.pollTimer = setTimeout(() => this.loadAria2cStatus(), 2000);
         }
     }
 

--- a/static/js/events.js
+++ b/static/js/events.js
@@ -147,8 +147,12 @@ export class EventHandler {
     }
 
     handleKeydown(e) {
+        if (e.defaultPrevented) return;
+        const target = e.target;
+        if (target instanceof Element && target.closest('input, textarea, select, dialog, [contenteditable="true"], .cm-editor, .editor-modal')) return;
+        const browserFocused = document.activeElement?.closest?.('.file-browser') || target?.closest?.('.file-browser');
         const keyActions = {
-            'Delete': () => this.app.selectedFiles.size > 0 && this.app.api.deleteSelectedFiles(),
+            'Delete': () => browserFocused && this.app.selectedFiles.size > 0 && this.app.api.deleteSelectedFiles(),
             'ArrowLeft': () => e.altKey && this.app.navigateToParent(),
             'f': () => e.ctrlKey && (e.preventDefault(), document.querySelector('.search-input')?.focus()),
             'n': () => {
@@ -159,6 +163,7 @@ export class EventHandler {
             },
             'u': () => e.ctrlKey && (e.preventDefault(), this.app.uploader.showUploadDialog()),
             'F2': () => {
+                if (!browserFocused) return;
                 if (this.app.selectedFiles.size === 1) {
                     const path = Array.from(this.app.selectedFiles)[0];
                     this.app.api.renameFile(path);

--- a/static/js/file-editor.js
+++ b/static/js/file-editor.js
@@ -77,6 +77,7 @@ export class FileEditor {
         this.app = app;
         this.currentFile = null;
         this.editorView = null;
+        this.saving = false;
         this.isPC = !/Mobi|Android/i.test(navigator.userAgent);
         this.vimCompartment = new Compartment();
 
@@ -208,6 +209,7 @@ export class FileEditor {
 
     open(filePath, content) {
         this.currentFile = filePath;
+        this.savedContent = content;
         this.filenameElement.textContent = filePath.split('/').pop();
 
         if (this.editorView) {
@@ -273,28 +275,34 @@ export class FileEditor {
     }
 
     async save() {
-        if (!this.currentFile || !this.editorView) return;
+        if (!this.currentFile || !this.editorView || this.saving) return;
 
         const content = this.editorView.state.doc.toString();
+        const filePath = this.currentFile;
+        this.saving = true;
 
         try {
             const response = await fetch('/api/files/save', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ path: this.currentFile, content: content })
+                body: JSON.stringify({ path: filePath, content: content })
             });
 
             const result = await response.json();
 
             if (result.success) {
                 this.showToast('File saved successfully', 'success');
-                this.close();
+                this.savedContent = content;
+                // Do not discard edits made while the request was in flight.
+                if (this.currentFile === filePath && this.editorView?.state.doc.toString() === content) this.close();
             } else {
                 this.showToast(result.message, 'error');
             }
         } catch (error) {
             this.showToast('Failed to save file', 'error');
             console.error('Error saving file:', error);
+        } finally {
+            this.saving = false;
         }
     }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -345,6 +345,7 @@ export class UIManager {
             this.sortState.direction = 'asc';
         }
         this.displayFiles(this.currentFiles);
+        this.app.uploader.bindUploadEvents();
     }
 
     sortFiles(files) {
@@ -553,6 +554,7 @@ export class UIManager {
     setViewMode(mode) {
         this.viewMode = mode;
         this.displayFiles(this.currentFiles);
+        this.app.uploader.bindUploadEvents();
     }
 
     showToast(title, message, type = 'info') {
@@ -607,7 +609,7 @@ export class UIManager {
 
     updateSidebarActiveState(path) {
         document.querySelectorAll('.sidebar .nav-item.active').forEach(item => item.classList.remove('active'));
-        const activeItem = document.querySelector(`.sidebar .nav-item[data-path="${path}"]`);
+        const activeItem = [...document.querySelectorAll('.sidebar .nav-item')].find(item => item.dataset.path === path);
         if (activeItem) activeItem.classList.add('active');
     }
 

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -6,6 +6,8 @@ export class UploadPageHandler {
         this.active = false;
         this.interval = null;
         this.selectedKeys = new Set();
+        this.polling = false;
+        this.timer = null;
         this.onJobsChanged = () => this.refresh();
     }
 
@@ -14,22 +16,27 @@ export class UploadPageHandler {
         this.active = true;
         window.addEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
         this.refresh();
-        this.interval = setInterval(() => this.refresh(), 3000);
         document.querySelector('.breadcrumbs')?.style.setProperty('display', 'none');
     }
 
     exit() {
         if (!this.active) return;
         this.active = false;
-        clearInterval(this.interval);
+        clearTimeout(this.timer);
         window.removeEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
         document.querySelector('.breadcrumbs')?.style.removeProperty('display');
     }
 
     async refresh() {
-        if (!this.active) return;
-        const jobs = await this.app.uploader.listJobs();
-        if (this.active) this.render(jobs);
+        if (!this.active || this.polling) return;
+        this.polling = true;
+        try {
+            const jobs = await this.app.uploader.listJobs();
+            if (this.active) this.render(jobs);
+        } finally {
+            this.polling = false;
+            if (this.active) this.timer = setTimeout(() => this.refresh(), 3000);
+        }
     }
 
     render(jobs) {

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -11,7 +11,10 @@ const PREPARE_BATCH_SIZE = 500;
 const DB_NAME = 'puremania-upload-sessions';
 const DB_STORE = 'sessions';
 
-const pause = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+const pause = (ms, signal) => new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => { clearTimeout(timer); reject(new DOMException('Upload interrupted', 'AbortError')); }, { once: true });
+});
 const yieldToBrowser = () => new Promise(resolve => setTimeout(resolve, 0));
 
 class AdaptiveUploadController {
@@ -76,9 +79,12 @@ class UploadSessionStore {
         return new Promise((resolve, reject) => {
             const tx = db.transaction(DB_STORE, mode);
             const request = action(tx.objectStore(DB_STORE));
-            request.onsuccess = () => resolve(request.result);
+            let result;
+            request.onsuccess = () => { result = request.result; };
             request.onerror = () => reject(request.error);
+            tx.oncomplete = () => resolve(result);
             tx.onerror = () => reject(tx.error);
+            tx.onabort = () => reject(tx.error || new Error('IndexedDB transaction aborted'));
         });
     }
 }
@@ -341,7 +347,7 @@ export class Uploader {
             xhr.upload.onprogress = event => { if (event.lengthComputable) onProgress(start + event.loaded); };
             xhr.onload = () => {
                 cleanup();
-                if (xhr.status >= 200 && xhr.status < 400) {
+                if (xhr.status === 200 || xhr.status === 308) {
                     controller?.record({
                         bytes: end - start + 1,
                         elapsed: performance.now() - startedAt,
@@ -349,7 +355,11 @@ export class Uploader {
                         writeTime: Number(xhr.getResponseHeader('Upload-Write-Time')) || 0,
                         recommendation: Number(xhr.getResponseHeader('Upload-Recommend-Concurrency')) || 0
                     });
-                    try { resolve(JSON.parse(xhr.responseText)); } catch (_) { resolve({ uploadedBytes: end + 1 }); }
+                    try {
+                        const result = JSON.parse(xhr.responseText);
+                        if (!Number.isInteger(result.uploadedBytes) || result.uploadedBytes < start || result.uploadedBytes > end + 1) throw new Error('Invalid upload position');
+                        resolve(result);
+                    } catch (error) { reject(error); }
                 } else { controller?.recordFailure(xhr.status); reject(new Error(`Chunk rejected (${xhr.status})`)); }
             };
             xhr.onerror = () => { cleanup(); controller?.recordFailure(); reject(new Error('Network error while sending chunk')); };
@@ -385,7 +395,7 @@ export class Uploader {
                     if (offset > end) { completed = true; break; }
                     if (attempt === MAX_RETRIES - 1) throw error;
                     this.setFileProgress(record.key, item, offset, `Retrying in ${2 ** attempt}s`);
-                    await pause((2 ** attempt) * 1000 + Math.floor(Math.random() * 250));
+                    await pause((2 ** attempt) * 1000 + Math.floor(Math.random() * 250), session.signal);
                 }
             }
             try { await this.store.put({ ...record, uploadedBytes: offset, updatedAt: Date.now() }); this.notifyJobsChanged(); } catch (_) { /* optional */ }
@@ -416,6 +426,10 @@ export class Uploader {
 
     async handleFileUpload(items, destinationOverride = null) {
         if (!items?.length) return;
+        if (this.activeUploadSession) {
+            this.app.ui.showToast('Upload in progress', 'Pause or finish the current upload first.', 'warning');
+            return;
+        }
         const session = this.createUploadSession();
         this.activeUploadSession = session;
         this.app.progressManager.setCurrentUpload(session);


### PR DESCRIPTION
## Summary
- ignore global file shortcuts in editors and form controls
- cancel stale directory requests and stale editor reads
- prevent overlapping upload batches and validate durable upload state
- serialize polling, preserve upload bindings after rerendering, and avoid unsafe sidebar selectors

## Tests
- bash build.sh
- go test ./...
- node --check static/js/{api,app,aria2c-page,events,file-editor,ui,upload-page,uploader}.js
- git diff --check