### PR TITLE
fix: keep frontend state transitions consistent

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -171,19 +171,16 @@ export class ApiClient {
                 this.app.ui.displayFiles(files);
                 this.app.ui.updateBreadcrumb(path);
                 this.app.ui.updateSidebarActiveState(path);
-                this.app.router.updatePath(path);
                 this.app.ui.updateToolbar();
             } else {
                 this.notifyApiError(`Failed to load directory: ${path}`);
                 this.app.ui.displayFiles([]);
-                this.app.router.updatePath(path);
             }
         } catch (error) {
             if (error.name === 'AbortError') return;
             if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
             this.notifyApiError('An unexpected error occurred while loading files.', { error, context: 'in loadFiles' });
             this.app.ui.displayFiles([]);
-            this.app.router.updatePath(path);
         } finally {
             if (requestId === this.directoryRequestId) this.app.ui.hideLoading();
         }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -165,6 +165,7 @@ class FileManagerApp {
             item.classList.remove('selected');
         });
         this.selectedFiles.clear();
+        this.lastSelectedIndex = -1;
         this.ui.updateToolbar();
     }
 

--- a/static/js/file-editor.js
+++ b/static/js/file-editor.js
@@ -265,6 +265,7 @@ export class FileEditor {
         if (this.editorElement.style.display === 'none') {
             return;
         }
+        if (this.editorView && this.editorView.state.doc.toString() !== this.savedContent && !window.confirm('Discard unsaved changes?')) return;
         this.editorElement.style.display = 'none';
         this.currentFile = null;
         if (this.editorView) {

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -4,6 +4,7 @@ export class Router {
     constructor() {
         this.routes = {};
         this.currentPath = '';
+        this.route = { page: 'files', path: '/' };
         this.isInitialized = false;
         this.onRouteChange = null;
         
@@ -54,6 +55,10 @@ export class Router {
         console.log('Initial route:', currentPath);
         
         this.currentPath = currentPath;
+        this.route = {
+            page: currentPath === '/system/uploads' ? 'uploads' : currentPath === '/system/aria2c' ? 'aria2c' : 'files',
+            path: currentPath
+        };
         
         if (this.onRouteChange) {
             // FileManagerAppの初期化を待つための遅延
@@ -168,6 +173,10 @@ export class Router {
         }
         
         this.currentPath = path;
+        this.route = {
+            page: path === '/system/uploads' ? 'uploads' : path === '/system/aria2c' ? 'aria2c' : 'files',
+            path
+        };
         
         // 登録されたルートのマッチングを試行
         const matchedRoute = this._findMatchingRoute(path);

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -15,6 +15,7 @@ export class UIManager {
         this.fileBrowserExtensionsVisible = false;
         this.lazyImageObserver = null;
         this.imageLoader = new ImageLoader();
+        this.pendingOperations = 0;
     }
 
     displayFiles(files) {
@@ -43,6 +44,7 @@ export class UIManager {
 
         if (!files || files.length === 0) {
             this.renderEmptyState(container);
+            this.syncSelectionClasses(container);
             return;
         }
 
@@ -61,6 +63,13 @@ export class UIManager {
         } else {
             this.renderStandardView(sortedFiles, container, hasMasonrySupport, hasVideoSupport);
         }
+        this.syncSelectionClasses(container);
+    }
+
+    syncSelectionClasses(container = document) {
+        container.querySelectorAll('.file-item, .masonry-item, .video-card').forEach(item => {
+            item.classList.toggle('selected', this.app.selectedFiles.has(item.dataset.path));
+        });
     }
 
     renderHeaderToggle() {
@@ -579,11 +588,17 @@ export class UIManager {
     }
 
     showLoading() {
-        document.getElementById('loading-overlay').style.display = 'flex';
+        this.pendingOperations++;
+        const overlay = document.getElementById('loading-overlay');
+        if (overlay) overlay.style.display = 'flex';
     }
 
     hideLoading() {
-        document.getElementById('loading-overlay').style.display = 'none';
+        this.pendingOperations = Math.max(0, this.pendingOperations - 1);
+        if (this.pendingOperations === 0) {
+            const overlay = document.getElementById('loading-overlay');
+            if (overlay) overlay.style.display = 'none';
+        }
     }
 
     updateSpecificDirs(dirs) {


### PR DESCRIPTION
## Summary
- commit route state before fetching directories and prevent stale updates
- reset selection anchors and derive selected DOM classes from selection state
- reference-count global loading and guard unsaved editor changes

## Tests
- go test ./...
- node --check static/js/{api,app,events,file-editor,router,ui}.js
- git diff --check