### PR TITLE
fix: detect video MIME types in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        media-types \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --system --uid 1000 --home-dir /home/puremania --create-home --shell /usr/bin/nologin puremania \

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime"
 	"net/http"
 	"os"
 	"os/exec"
@@ -426,10 +425,7 @@ func (h *Handler) processDirectoryEntries(entries []os.DirEntry, basePath string
 			isEditable := false
 
 			if !entry.IsDir() {
-				mimeType = mime.TypeByExtension(filepath.Ext(entry.Name()))
-				if mimeType == "" {
-					mimeType = "application/octet-stream"
-				}
+				mimeType = mediaTypeByPath(entry.Name())
 				isEditable = utils.IsTextFile(mimeType) || utils.IsEditableByExtension(entry.Name())
 			} else {
 				mimeType = "application/octet-stream"
@@ -681,10 +677,7 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType := mime.TypeByExtension(filepath.Ext(path))
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
+	contentType := mediaTypeByPath(path)
 
 	filename := filepath.Base(path)
 	w.Header().Set("Content-Type", contentType)
@@ -722,7 +715,7 @@ func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mimeType := mime.TypeByExtension(filepath.Ext(path))
+	mimeType := mediaTypeByPath(path)
 
 	// 画像ファイルの場合はhttp.ServeFileで最適化
 	if mimeType != "" && strings.HasPrefix(mimeType, "image/") {

--- a/handlers/resumable_upload_handlers_test.go
+++ b/handlers/resumable_upload_handlers_test.go
@@ -121,3 +121,15 @@ func TestProtectedRootCannotBeDeletedAndSymlinkEscapesAreRejected(t *testing.T) 
 		t.Fatalf("storage root was removed: %v", err)
 	}
 }
+
+func TestMediaTypeByPathHasContainerIndependentVideoFallbacks(t *testing.T) {
+	for path, want := range map[string]string{
+		"clip.mp4":  "video/mp4",
+		"clip.webm": "video/webm",
+		"clip.mkv":  "video/x-matroska",
+	} {
+		if got := mediaTypeByPath(path); got != want {
+			t.Errorf("mediaTypeByPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/handlers/search_handlers.go
+++ b/handlers/search_handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -178,10 +177,7 @@ func (h *Handler) searchCurrentParallel(ctx context.Context, path string, matchF
 					}
 				}
 
-				mimeType := mime.TypeByExtension(filepath.Ext(entry.Name()))
-				if mimeType == "" {
-					mimeType = "application/octet-stream"
-				}
+				mimeType := mediaTypeByPath(entry.Name())
 
 				fullPath := filepath.Join(path, entry.Name())
 				virtualPath := h.convertToVirtualPath(fullPath)
@@ -244,10 +240,7 @@ func (h *Handler) searchRecursiveParallel(ctx context.Context, path string, matc
 				}
 			}
 
-			mimeType := mime.TypeByExtension(filepath.Ext(d.Name()))
-			if mimeType == "" {
-				mimeType = "application/octet-stream"
-			}
+			mimeType := mediaTypeByPath(d.Name())
 
 			virtualPath := h.convertToVirtualPath(filePath)
 

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +14,25 @@ import (
 	"sort"
 	"strings"
 )
+
+var fallbackMediaTypes = map[string]string{
+	".mp4": "video/mp4", ".m4v": "video/mp4", ".webm": "video/webm",
+	".ogv": "video/ogg", ".mov": "video/quicktime", ".mkv": "video/x-matroska",
+	".avi": "video/x-msvideo", ".mpeg": "video/mpeg", ".mpg": "video/mpeg", ".ts": "video/mp2t",
+	".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".flac": "audio/flac",
+	".ogg": "audio/ogg", ".opus": "audio/ogg", ".wav": "audio/wav",
+}
+
+func mediaTypeByPath(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	if mediaType := fallbackMediaTypes[ext]; mediaType != "" {
+		return mediaType
+	}
+	if mediaType := mime.TypeByExtension(ext); mediaType != "" {
+		return mediaType
+	}
+	return "application/octet-stream"
+}
 
 // 物理パスを仮想パスに変換するメソッド
 func (h *Handler) convertToVirtualPath(physicalPath string) string {


### PR DESCRIPTION
## Summary
- install media-types in the runtime image
- add application-level media MIME fallbacks independent of OS MIME files
- share MIME resolution between file listing, search, and downloads

## Tests
- go test ./...
- go vet ./...
- git diff --check