### PR TITLE
fix: use built-in container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
         media-types \
     && rm -rf /var/lib/apt/lists/*
 
@@ -51,6 +50,6 @@ USER puremania
 EXPOSE 8844
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -fsS http://127.0.0.1:${PORT}/api/health || exit 1
+    CMD ["/app/puremania", "healthcheck"]
 
 ENTRYPOINT ["/app/puremania"]

--- a/handlers/system_handlers.go
+++ b/handlers/system_handlers.go
@@ -78,18 +78,18 @@ func (h *Handler) GetStorageInfo(w http.ResponseWriter, r *http.Request) {
 
 // ヘルスチェック用エンドポイント
 func (h *Handler) HealthCheck(w http.ResponseWriter, r *http.Request) {
-	cacheEntries, cacheSize := cache.Stats(h.cache)
-	status := map[string]interface{}{
-		"status":         "healthy",
-		"timestamp":      time.Now().Format(time.RFC3339),
-		"active_workers": worker.ActiveWorkers(h.workerPool),
-		"cache_stats": map[string]interface{}{
-			"entries": cacheEntries,
-			"size":    cacheSize,
-		},
+	dir, err := os.Open(h.config.StorageDir)
+	if err != nil {
+		h.respondError(w, "Storage is unavailable", http.StatusServiceUnavailable)
+		return
 	}
-
-	h.respondSuccess(w, status)
+	defer dir.Close()
+	if _, err := dir.Stat(); err != nil {
+		h.respondError(w, "Storage is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 // GetSpecificDirs は、設定された特定のディレクトリのリストを返す

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRunHealthcheckURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+	if code := runHealthcheckURL(server.URL, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("healthcheck exit code = %d", code)
+	}
+}
+
+func TestRunHealthcheckURLRejectsUnexpectedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"unhealthy"}`))
+	}))
+	defer server.Close()
+	if code := runHealthcheckURL(server.URL, &bytes.Buffer{}); code != 1 {
+		t.Fatalf("healthcheck exit code = %d, want 1", code)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -121,6 +124,9 @@ func LoadConfig(logger *slog.Logger) *types.Config {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		os.Exit(runHealthcheck())
+	}
 	// ロガーを初期化
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
@@ -227,6 +233,51 @@ func main() {
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Error("Server stopped", "error", err)
 	}
+}
+
+func runHealthcheck() int {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	port := getEnvAsInt(logger, "PORT", 8844)
+	return runHealthcheckURL(fmt.Sprintf("http://127.0.0.1:%d/api/health", port), os.Stderr)
+}
+
+func runHealthcheckURL(url string, stderr io.Writer) int {
+	client := &http.Client{
+		Timeout: 4 * time.Second,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext:       (&net.Dialer{Timeout: 2 * time.Second, KeepAlive: -1}).DialContext,
+		},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "puremania-healthcheck")
+	response, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		fmt.Fprintf(stderr, "unexpected HTTP status: %s\n", response.Status)
+		return 1
+	}
+	var health struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 4<<10)).Decode(&health); err != nil {
+		fmt.Fprintf(stderr, "invalid health response: %v\n", err)
+		return 1
+	}
+	if health.Status != "ok" {
+		fmt.Fprintf(stderr, "unhealthy status: %q\n", health.Status)
+		return 1
+	}
+	return 0
 }
 
 func staticCacheMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary
- replace curl-based Docker health checks with a built-in binary subcommand
- validate HTTP status and bounded JSON health responses
- report unavailable storage as unhealthy

## Tests
- go test ./...
- go vet ./...
- git diff --check