### PR TITLE
ci: upgrade golangci-lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             ${{ runner.os }}-golangci-lint-
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           skip-cache: true


### PR DESCRIPTION
Updates golangci-lint-action to v7 so the workflow runs on the supported Node runtime.