### PR TITLE
fix: restore directory scroll only on history navigation

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -75,7 +75,7 @@ class FileManagerApp {
         this.updateStorageInfo(storageResult);
 
         // Setup router
-        this.router.onChange((path) => {
+        this.router.onChange((path, { navigationType = 'initial' } = {}) => {
             if (path === '/system/uploads') {
                 if (this.aria2cPageHandler.isInAria2cMode) this.aria2cPageHandler.exitAria2cMode(false);
                 this.uploadPageHandler.enter();
@@ -95,7 +95,7 @@ class FileManagerApp {
                 if (this.aria2cPageHandler.isInAria2cMode) {
                     this.aria2cPageHandler.exitAria2cMode(false);
                 }
-                this.navigateToPath(path);
+                this.navigateToPath(path, { restoreScroll: navigationType === 'pop' });
             }
         });
     }
@@ -105,13 +105,13 @@ class FileManagerApp {
         this.uploader.bindUploadEvents();
     }
 
-    async navigateToPath(path) {
+    async navigateToPath(path, { restoreScroll = false } = {}) {
         const browser = document.querySelector('.file-browser');
         if (browser && this.renderedDirectoryPath && this.renderedDirectoryPath !== path) {
             this.directoryScrollPositions.set(this.renderedDirectoryPath, browser.scrollTop);
         }
         await this.loadFiles(path);
-        const restorePosition = this.directoryScrollPositions.get(path) || 0;
+        const restorePosition = restoreScroll ? (this.directoryScrollPositions.get(path) ?? 0) : 0;
         // File rendering replaces the browser contents. Restore after layout so
         // new directories start at the top while revisited ones retain context.
         requestAnimationFrame(() => {

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -4,6 +4,7 @@ export class Router {
     constructor() {
         this.routes = {};
         this.currentPath = '';
+        this.navigationType = 'initial';
         this.route = { page: 'files', path: '/' };
         this.isInitialized = false;
         this.onRouteChange = null;
@@ -18,6 +19,7 @@ export class Router {
      */
     _setupEventListeners() {
         window.addEventListener('popstate', () => {
+            this.navigationType = 'pop';
             this.handleRouteChange();
         });
     }
@@ -63,7 +65,7 @@ export class Router {
         if (this.onRouteChange) {
             // FileManagerAppの初期化を待つための遅延
             setTimeout(() => {
-                this.onRouteChange(currentPath);
+                this.onRouteChange(currentPath, { navigationType: 'initial' });
             }, 100);
         }
     }
@@ -80,7 +82,7 @@ export class Router {
         if (cleanPath === this.currentPath) return;
         
         console.log('Navigating to:', cleanPath);
-        
+        this.navigationType = 'push';
         this._updateBrowserHistory(cleanPath, 'push');
         this.handleRouteChange();
     }
@@ -177,19 +179,21 @@ export class Router {
             page: path === '/system/uploads' ? 'uploads' : path === '/system/aria2c' ? 'aria2c' : 'files',
             path
         };
+        const navigationType = this.navigationType;
+        this.navigationType = 'unknown';
         
         // 登録されたルートのマッチングを試行
         const matchedRoute = this._findMatchingRoute(path);
         if (matchedRoute) {
             console.log('Route matched:', matchedRoute);
-            this.routes[matchedRoute](path);
+            this.routes[matchedRoute](path, { navigationType });
             return;
         }
         
         // デフォルトハンドラーを呼び出し
         if (this.onRouteChange) {
             console.log('Calling onRouteChange with:', path);
-            this.onRouteChange(path);
+            this.onRouteChange(path, { navigationType });
         }
     }
 
@@ -261,7 +265,7 @@ export class Router {
         // 既に初期化済みの場合は即座にコールバックを実行
         if (this.isInitialized && this.currentPath) {
             setTimeout(() => {
-                callback(this.currentPath);
+                callback(this.currentPath, { navigationType: 'initial' });
             }, 10);
         }
     }


### PR DESCRIPTION
## Summary
- distinguish push, pop, and initial route changes
- reset directory scroll position for normal navigation
- restore saved scroll positions only for browser back/forward

## Tests
- go test ./...
- node --check static/js/router.js
- node --check static/js/app.js
- git diff --check