### PR TITLE
feat: preallocate resumable upload storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ The following environment variables can be configured in the `.env` file:
 | `MOUNT_DIRS`       | Comma-separated list of additional directories to mount.                                                                                               | (empty)              |  
 | `MAX_FILE_SIZE_MB` | Maximum file size for uploads in megabytes.                                                                                                            | `102400`             |
 | `UPLOAD_SESSION_TTL_HOURS` | Hours that an interrupted resumable-upload session is retained for resumption.                                                              | `168`                |
+| `UPLOAD_PREALLOCATE` | Reserve disk blocks when a resumable upload session is created (Linux). Set `false` for sparse-file or thin-provisioned storage. | `true` |
 | `PORT`             | The port on which the server will run.                                                                                                                 | `8844`               |  
 | `ZIP_TIMEOUT`      | Timeout in seconds for ZIP file creation.                                                                                                              | `300`                |  
 | `MAX_ZIP_SIZE`     | Maximum size in MB for files to be zipped.                                                                                                             | `1024`               |

--- a/handlers/preallocate_linux.go
+++ b/handlers/preallocate_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package handlers
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// preallocateUpload reserves blocks without changing the logical EOF. This
+// works with retry truncation while still reporting ENOSPC at session creation.
+func preallocateUpload(file *os.File, size int64) error {
+	err := unix.Fallocate(int(file.Fd()), unix.FALLOC_FL_KEEP_SIZE, 0, size)
+	if errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) {
+		return nil
+	}
+	return err
+}

--- a/handlers/preallocate_other.go
+++ b/handlers/preallocate_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package handlers
+
+import "os"
+
+func preallocateUpload(_ *os.File, _ int64) error { return nil }

--- a/handlers/resumable_upload_handlers.go
+++ b/handlers/resumable_upload_handlers.go
@@ -164,15 +164,23 @@ func (h *Handler) CreateUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	session := &uploadSession{ID: id, Destination: destination, RelativePath: relativePath, TotalBytes: req.Size, CreatedAt: now, UpdatedAt: now, Fingerprint: req.Fingerprint}
-	// A zero-byte upload has no chunk request. Create its empty part now so
-	// completion follows the same atomic rename path as every other upload.
-	if req.Size == 0 {
-		part, createErr := os.OpenFile(h.uploadTempPath(id), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-		if createErr != nil {
-			h.respondError(w, "Cannot create upload data", http.StatusInternalServerError)
-			return
-		}
-		_ = part.Close()
+	// Reserve storage before acknowledging the session. KEEP_SIZE allocation
+	// preserves resumable writes' logical length and catches ENOSPC early.
+	part, createErr := os.OpenFile(h.uploadTempPath(id), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if createErr != nil {
+		h.respondError(w, "Cannot create upload data", http.StatusInternalServerError)
+		return
+	}
+	if req.Size > 0 && h.config.PreallocateUploads {
+		createErr = preallocateUpload(part, req.Size)
+	}
+	if closeErr := part.Close(); createErr == nil {
+		createErr = closeErr
+	}
+	if createErr != nil {
+		_ = os.Remove(h.uploadTempPath(id))
+		h.respondError(w, "Cannot reserve upload storage", http.StatusInsufficientStorage)
+		return
 	}
 	if err := h.writeUploadSession(session); err != nil {
 		_ = os.Remove(h.uploadTempPath(id))

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ func LoadConfig(logger *slog.Logger) *types.Config {
 		MaxZipSize:            getEnvAsInt64(logger, "MAX_ZIP_SIZE", 1024),
 		SpecificDirs:          getEnvAsStringSlice("SPECIFIC_DIRS", []string{}),
 		UploadSessionTTLHours: getEnvAsInt(logger, "UPLOAD_SESSION_TTL_HOURS", 168),
+		PreallocateUploads:    getEnvAsBool("UPLOAD_PREALLOCATE", true),
 		// Aria2cEnabled は後で設定
 	}
 
@@ -299,6 +300,18 @@ func getEnv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func getEnvAsBool(key string, fallback bool) bool {
+	value, exists := os.LookupEnv(key)
+	if !exists {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
 }
 
 // getEnvAsInt は環境変数を整数として読み込み

--- a/types/config.go
+++ b/types/config.go
@@ -13,4 +13,5 @@ type Config struct {
 	Aria2cRPCToken        string
 	Aria2cEnabled         bool
 	UploadSessionTTLHours int
+	PreallocateUploads    bool
 }


### PR DESCRIPTION
## Summary
- reserve disk blocks when resumable upload sessions are created on Linux
- fail early when storage is exhausted while retaining retry-safe logical file lengths
- allow sparse or thin-provisioned deployments to opt out with UPLOAD_PREALLOCATE=false

## Tests
- go test ./...
- go vet ./...
- git diff --check