### PR TITLE
fix: bound directory caches and revalidate HTML

### DIFF
--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -292,6 +292,7 @@ func getOptimalBufferSize(fileSize int64) int {
 
 // ListFiles - TTLキャッシュ、ETagによる差分検知を使用
 func (h *Handler) ListFiles(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "private, no-cache")
 	path := r.URL.Query().Get("path")
 	if path == "" {
 		path = "/"
@@ -689,6 +690,7 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 
 // GetFileContent - 画像はhttp.ServeFileで最適化、テキストはキャッシュ使用
 func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "private, no-cache")
 	path := r.URL.Query().Get("path")
 	if path == "" {
 		h.respondError(w, "Path required", http.StatusBadRequest)

--- a/main.go
+++ b/main.go
@@ -201,12 +201,23 @@ func main() {
 	// 静的ファイルのサービス
 	staticFileHandler := http.StripPrefix("/static/", staticCacheMiddleware(http.FileServer(http.Dir("./static/"))))
 	r.PathPrefix("/static/").Handler(staticFileHandler)
+	indexETag := ""
+	if info, err := os.Stat("./static/index.html"); err == nil {
+		indexETag = fmt.Sprintf("\"%x-%x\"", info.ModTime().UnixNano(), info.Size())
+	}
 
 	// その他のリクエストはindex.htmlを返す
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Cache-Control", "no-cache, must-revalidate")
 		// APIパス以外はindex.htmlを返す
 		if !strings.HasPrefix(r.URL.Path, "/api/") && !strings.HasPrefix(r.URL.Path, "/static/") {
+			if indexETag != "" {
+				w.Header().Set("ETag", indexETag)
+				if r.Header.Get("If-None-Match") == indexETag {
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
+			}
 			http.ServeFile(w, r, "./static/index.html")
 		} else {
 			// muxがよしなに処理してくれるので、ここはシンプルに
@@ -220,6 +231,7 @@ func main() {
 		Addr:              fmt.Sprintf(":%d", cfg.Port),
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    32 << 10,
 	}
 	shutdownContext, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,6 +1,9 @@
 import { showConfirmDialog, showPromptDialog } from './modal.js';
 import { buildApiUrl } from './util.js';
 
+const MAX_CACHED_DIRECTORIES = 20;
+const MAX_CACHED_ENTRIES = 100000;
+
 export class ApiClient {
     constructor(app) {
         this.app = app;
@@ -8,6 +11,28 @@ export class ApiClient {
         this.directoryCache = new Map();
         this.directoryRequestId = 0;
         this.directoryAbortController = null;
+    }
+
+    cacheDirectory(path, etag, files) {
+        // Do not retain a single massive listing in addition to its rendered UI.
+        if (files.length > MAX_CACHED_ENTRIES) {
+            this.directoryEtags.delete(path);
+            this.directoryCache.delete(path);
+            return;
+        }
+        this.directoryEtags.set(path, etag);
+        this.directoryCache.set(path, { files, usedAt: Date.now() });
+        while (this.directoryCache.size > MAX_CACHED_DIRECTORIES || this.cachedEntryCount() > MAX_CACHED_ENTRIES) {
+            const oldest = [...this.directoryCache.entries()].reduce((candidate, entry) => entry[1].usedAt < candidate[1].usedAt ? entry : candidate)[0];
+            this.directoryCache.delete(oldest);
+            this.directoryEtags.delete(oldest);
+        }
+    }
+
+    cachedEntryCount() {
+        let count = 0;
+        for (const entry of this.directoryCache.values()) count += entry.files.length;
+        return count;
     }
 
     async postJson(url, payload) {
@@ -129,7 +154,9 @@ export class ApiClient {
 
             if (response.status === 304) {
                 console.log(`Content for ${path} not modified. Using cache.`);
-                return this.directoryCache.get(path);
+                const cached = this.directoryCache.get(path);
+                if (cached) cached.usedAt = Date.now();
+                return cached?.files || null;
             }
 
             if (!response.ok) {
@@ -142,10 +169,7 @@ export class ApiClient {
             
             if (result.success) {
                 const files = result.data || [];
-                if (newEtag) {
-                    this.directoryEtags.set(path, newEtag);
-                }
-                this.directoryCache.set(path, files);
+                this.cacheDirectory(path, newEtag || '', files);
                 return files;
             } else {
                 throw new Error(result.message || 'API returned success:false');


### PR DESCRIPTION
## Summary
- revalidate the SPA shell with ETag instead of forbidding caching
- apply private revalidation caching to directory and editor-content APIs
- bound client directory cache entries and total cached files
- limit server request header size

## Tests
- go test ./...
- go vet ./...
- node --check static/js/api.js
- git diff --check