### PR TITLE
fix: balance directory loading state

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -206,7 +206,9 @@ export class ApiClient {
             this.notifyApiError('An unexpected error occurred while loading files.', { error, context: 'in loadFiles' });
             this.app.ui.displayFiles([]);
         } finally {
-            if (requestId === this.directoryRequestId) this.app.ui.hideLoading();
+            // Every request owns one loading reference, including requests that
+            // become stale or are aborted by a newer navigation.
+            this.app.ui.hideLoading();
         }
     }
 


### PR DESCRIPTION
## Summary
- balance the loading reference for every directory request
- allow stale and aborted navigation requests to release their loading state
- keep request freshness checks limited to rendering results

## Tests
- npm run build
- go test ./...
- go vet ./...
- node --check static/js/api.js
- git diff --check