### PR TITLE
fix: avoid injecting dynamic UI content

### DIFF
--- a/static/js/aria2c-page.js
+++ b/static/js/aria2c-page.js
@@ -183,7 +183,7 @@ export class Aria2cPageHandler {
         template.querySelector('.progress-text').textContent = `${progress.toFixed(2)}%`;
         template.querySelector('.status').textContent = item.status;
         template.querySelector('.speed').textContent = `${this.fileManager.ui.formatFileSize(downloadSpeed)}/s`;
-        template.querySelector('.actions').innerHTML = this.createActionButtons(item.status, item.gid);
+        template.querySelector('.actions').replaceChildren(...this.createActionButtons(item.status, item.gid));
         
         tr.appendChild(template);
         return tr;
@@ -194,22 +194,31 @@ export class Aria2cPageHandler {
     }
 
     createActionButtons(status, gid) {
-        let buttons = '';
+        const buttons = [];
+        const addButton = (label, action, className) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `btn btn-sm ${className}`;
+            button.dataset.action = action;
+            button.dataset.gid = gid;
+            button.textContent = label;
+            buttons.push(button);
+        };
         switch (status) {
             case 'active':
-                buttons += `<button class="btn btn-sm btn-warning" data-action="pause" data-gid="${gid}">Pause</button>`;
-                buttons += `<button class="btn btn-sm btn-danger" data-action="cancel" data-gid="${gid}">Cancel</button>`;
+                addButton('Pause', 'pause', 'btn-warning');
+                addButton('Cancel', 'cancel', 'btn-danger');
                 break;
             case 'paused':
-                buttons += `<button class="btn btn-sm btn-success" data-action="resume" data-gid="${gid}">Resume</button>`;
-                buttons += `<button class="btn btn-sm btn-danger" data-action="cancel" data-gid="${gid}">Cancel</button>`;
+                addButton('Resume', 'resume', 'btn-success');
+                addButton('Cancel', 'cancel', 'btn-danger');
                 break;
             case 'complete':
-                 buttons += `<button class="btn btn-sm btn-info" data-action="clear" data-gid="${gid}">Clear</button>`;
+                addButton('Clear', 'clear', 'btn-info');
                 break;
             case 'error':
             case 'removed':
-                 buttons += `<button class="btn btn-sm btn-info" data-action="clear" data-gid="${gid}">Clear</button>`;
+                addButton('Clear', 'clear', 'btn-info');
                 break;
         }
         return buttons;

--- a/static/js/media-player.js
+++ b/static/js/media-player.js
@@ -559,7 +559,7 @@ export class MediaPlayer {
             <div class="modal">
                 <div class="modal-header">
                     <div class="video-modal-header-main">
-                        <div class="modal-title" title="${fileName}">${fileName}</div>
+                        <div class="modal-title"></div>
                         <div class="video-modal-meta">Esc: close / Space: play-pause / ← →: seek 5s</div>
                     </div>
                     <button class="modal-close">&times;</button>
@@ -570,6 +570,9 @@ export class MediaPlayer {
             </div>
         `
         });
+        const title = modal.querySelector('.modal-title');
+        title.textContent = fileName;
+        title.title = fileName;
         const video = modal.querySelector('video');
         video.src = buildApiUrl('/api/files/download', { path: this.currentMedia.path });
         video.volume = this.volume;

--- a/static/js/progress.js
+++ b/static/js/progress.js
@@ -66,7 +66,11 @@ export class ProgressManager {
         const closeBtn = this.progressOverlay.querySelector('.progress-close');
 
         if (statusElement) {
-            statusElement.innerHTML = `Error: ${message}<br><strong>Click close to dismiss</strong>`;
+            statusElement.replaceChildren();
+            statusElement.append(document.createTextNode(`Error: ${message}`), document.createElement('br'));
+            const dismissHint = document.createElement('strong');
+            dismissHint.textContent = 'Click close to dismiss';
+            statusElement.appendChild(dismissHint);
             statusElement.style.color = 'var(--error, #f44336)';
         }
 


### PR DESCRIPTION
## Summary
- render video filenames with textContent instead of HTML interpolation
- build aria2 action buttons with DOM APIs and safe dataset assignments
- render upload error messages without injecting HTML

## Tests
- npm run build
- go test ./...
- go vet ./...
- node --check static/js/media-player.js
- node --check static/js/progress.js
- node --check static/js/aria2c-page.js
- git diff --check