### PR TITLE
fix: make upload progress accessible

### DIFF
--- a/static/js/progress.js
+++ b/static/js/progress.js
@@ -33,6 +33,9 @@ export class ProgressManager {
     }
 
     startTimer() {
+        if (this.timerInterval !== null) {
+            clearInterval(this.timerInterval);
+        }
         this.startTime = Date.now();
         this.timerInterval = setInterval(() => {
             if (!this.isCompleted) {
@@ -66,6 +69,8 @@ export class ProgressManager {
         const closeBtn = this.progressOverlay.querySelector('.progress-close');
 
         if (statusElement) {
+            statusElement.setAttribute('role', 'alert');
+            statusElement.setAttribute('aria-live', 'assertive');
             statusElement.replaceChildren();
             statusElement.append(document.createTextNode(`Error: ${message}`), document.createElement('br'));
             const dismissHint = document.createElement('strong');
@@ -95,6 +100,8 @@ export class ProgressManager {
         const closeBtn = this.progressOverlay.querySelector('.progress-close');
 
         if (statusElement) {
+            statusElement.setAttribute('role', 'status');
+            statusElement.setAttribute('aria-live', 'polite');
             statusElement.style.color = '';
         }
 
@@ -134,6 +141,7 @@ export class ProgressManager {
         const elements = {
             current: this.progressOverlay.querySelector('.progress-current'),
             barFill: this.progressOverlay.querySelector('.ui-progress__fill'),
+            progressBar: this.progressOverlay.querySelector('.ui-progress'),
             percentage: this.progressOverlay.querySelector('.progress-percentage'),
             stats: this.progressOverlay.querySelector('.progress-stats'),
             status: this.progressOverlay.querySelector('.progress-status')
@@ -141,6 +149,7 @@ export class ProgressManager {
 
         if (elements.current) elements.current.textContent = currentFile;
         if (elements.barFill) elements.barFill.style.width = percentageText;
+        if (elements.progressBar) elements.progressBar.setAttribute('aria-valuenow', String(Math.round(safePercentage)));
         if (elements.percentage) elements.percentage.textContent = percentageText;
         if (elements.stats) elements.stats.textContent = statsText;
         if (elements.status && status) elements.status.textContent = status;

--- a/static/templates/components/progress_overlay.html
+++ b/static/templates/components/progress_overlay.html
@@ -3,14 +3,14 @@
         <div class="progress-header">
             <div class="progress-title">Uploading Files</div>
             <div class="progress-actions">
-                <button class="progress-minimize" type="button" title="Minimize upload status">−</button>
-                <button class="progress-close" type="button" title="Close upload status">&times;</button>
+                <button class="progress-minimize" type="button" aria-label="Minimize upload status">−</button>
+                <button class="progress-close" type="button" aria-label="Close upload status">&times;</button>
             </div>
         </div>
         <div class="progress-info">
             <span class="progress-current">Preparing files...</span>
         </div>
-        <div class="ui-progress">
+        <div class="ui-progress" role="progressbar" aria-label="Upload progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
             <div class="ui-progress__fill"></div>
         </div>
         <div class="progress-details">
@@ -18,9 +18,9 @@
             <span class="progress-stats">0 files processed</span>
             <span class="progress-time">Elapsed: 0s</span>
         </div>
-        <div class="progress-status">Initializing...</div>
+        <div class="progress-status" role="status" aria-live="polite" aria-atomic="true">Initializing...</div>
     </div>
     <div class="upload-minimized">
-        <button type="button" class="upload-restore">⇧ Uploads</button>
+        <button type="button" class="upload-restore" aria-label="Restore upload status">⇧ Uploads</button>
     </div>
 </template>


### PR DESCRIPTION
## Summary
- prevent duplicate elapsed-time intervals when progress is shown repeatedly
- expose upload progress values through progressbar semantics
- announce normal status politely and errors assertively
- provide accessible names for progress controls

## Tests
- go test ./...
- go vet ./...
- node --check static/js/progress.js
- git diff --check