### PR TITLE
fix: announce application notifications

### DIFF
--- a/static/js/file-editor.js
+++ b/static/js/file-editor.js
@@ -308,16 +308,6 @@ export class FileEditor {
     }
 
     showToast(message, type) {
-        if (window.fileManager && window.fileManager.showToast) {
-            window.fileManager.showToast('Editor', message, type);
-            return;
-        }
-
-        const toast = document.createElement('div');
-        toast.className = 'toast-message';
-        toast.textContent = message;
-        toast.style.background = type === 'success' ? 'var(--success)' : 'var(--error)';
-        document.body.appendChild(toast);
-        setTimeout(() => toast.remove(), 3000);
+        this.app.ui.showToast('Editor', message, type);
     }
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -572,6 +572,9 @@ export class UIManager {
 
         const toast = document.createElement('div');
         toast.className = `toast toast-${type}`;
+        toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+        toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+        toast.setAttribute('aria-atomic', 'true');
         const template = getTemplateContent('/static/templates/components/toast.html');
         template.querySelector('.toast-title').textContent = title;
         template.querySelector('.toast-message').textContent = message;
@@ -584,7 +587,7 @@ export class UIManager {
             setTimeout(() => toast.remove(), 300);
         };
         toast.querySelector('.toast-close').addEventListener('click', removeToast);
-        setTimeout(removeToast, 5000);
+        setTimeout(removeToast, type === 'error' ? 10000 : 5000);
     }
 
     showLoading() {

--- a/static/templates/components/toast.html
+++ b/static/templates/components/toast.html
@@ -3,5 +3,5 @@
         <div class="toast-title"></div>
         <div class="toast-message"></div>
     </div>
-    <button class="toast-close">&times;</button>
+    <button type="button" class="toast-close" aria-label="Close notification">&times;</button>
 </template>


### PR DESCRIPTION
## Summary
- expose toast notifications as polite status or assertive alert messages
- keep error notifications visible longer than routine status updates
- provide an accessible close label
- route editor messages through the shared notification UI

## Tests
- go test ./...
- go vet ./...
- node --check static/js/ui.js
- node --check static/js/file-editor.js
- git diff --check