### PR TITLE
fix: manage modal focus and semantics

### DIFF
--- a/static/js/file-editor.js
+++ b/static/js/file-editor.js
@@ -18,7 +18,7 @@ import { html } from "@codemirror/lang-html";
 import { css } from "@codemirror/lang-css";
 import { xml } from "@codemirror/lang-xml";
 import { markdown } from "@codemirror/lang-markdown";
-import { createModalOverlay } from "./modal.js";
+import { createModalOverlay, hideModalOverlay, showModalOverlay } from "./modal.js";
 
 const getLanguageName = (filePath) => {
     const extension = filePath.split('.').pop().toLowerCase();
@@ -234,7 +234,7 @@ export class FileEditor {
             parent: this.editorContainer
         });
 
-        this.editorElement.style.display = 'flex';
+        showModalOverlay(this.editorElement);
         this.editorView.focus();
         document.body.style.overflow = 'hidden';
 
@@ -266,7 +266,7 @@ export class FileEditor {
             return;
         }
         if (this.editorView && this.editorView.state.doc.toString() !== this.savedContent && !window.confirm('Discard unsaved changes?')) return;
-        this.editorElement.style.display = 'none';
+        hideModalOverlay(this.editorElement);
         this.currentFile = null;
         if (this.editorView) {
             this.editorView.destroy();

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,5 +1,5 @@
 import { getTemplateContent } from './template.js';
-import { createModalOverlay, bindModalClose } from './modal.js';
+import { createModalOverlay, bindModalClose, hideModalOverlay, showModalOverlay } from './modal.js';
 import { buildApiUrl } from './util.js';
 import { ImageLoader } from './image-loader.js';
 
@@ -74,14 +74,14 @@ export class ImageViewer {
         }
         
         this.showImage(this.currentImageIndex);
-        this.viewerElement.style.display = 'flex';
+        showModalOverlay(this.viewerElement, { initialFocus: this.viewerElement.querySelector('.modal-close') });
         this.isOpen = true;
         document.body.style.overflow = 'hidden';
         this.showNavButtons();
     }
     
     close() {
-        this.viewerElement.style.display = 'none';
+        hideModalOverlay(this.viewerElement);
         this.isOpen = false;
         document.body.style.overflow = '';
         clearTimeout(this.navTimeout);

--- a/static/js/media-player.js
+++ b/static/js/media-player.js
@@ -1,4 +1,4 @@
-import { createModalOverlay, bindModalClose } from './modal.js';
+import { createModalOverlay, bindModalClose, hideModalOverlay, showModalOverlay } from './modal.js';
 import { buildApiUrl } from './util.js';
 
 export class MediaPlayer {
@@ -583,6 +583,7 @@ export class MediaPlayer {
         });
         this.videoModal = modal;
         this.isVideoModalOpen = true;
+        showModalOverlay(modal, { initialFocus: video });
         document.addEventListener('keydown', this.boundVideoModalKeydown);
         video.focus();
         video.addEventListener('loadedmetadata', () => this.updateProgress());
@@ -603,6 +604,7 @@ export class MediaPlayer {
             this.modalVideoElement.pause();
             this.modalVideoElement.src = '';
         }
+        hideModalOverlay(this.videoModal);
         this.videoModal.remove();
         this.videoModal = null;
         this.modalVideoElement = null;

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,8 +1,12 @@
 export function createModalOverlay({ className = '', hidden = false, content = null } = {}) {
     const modal = document.createElement('div');
     modal.className = `modal-overlay${className ? ` ${className}` : ''}`;
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.tabIndex = -1;
     if (hidden) {
         modal.style.display = 'none';
+        modal.setAttribute('aria-hidden', 'true');
     }
 
     if (typeof content === 'string') {
@@ -11,8 +15,40 @@ export function createModalOverlay({ className = '', hidden = false, content = n
         modal.appendChild(content);
     }
 
+    const title = modal.querySelector('.modal-title, .editor-title, h1, h2');
+    if (title) {
+        title.id ||= `modal-title-${crypto.randomUUID()}`;
+        modal.setAttribute('aria-labelledby', title.id);
+    } else {
+        modal.setAttribute('aria-label', 'Dialog');
+    }
+
     document.body.appendChild(modal);
     return modal;
+}
+
+const focusableSelector = [
+    'a[href]', 'button:not([disabled])', 'input:not([disabled])',
+    'select:not([disabled])', 'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+export function showModalOverlay(modal, { initialFocus = null } = {}) {
+    if (!modal) return;
+    modal._previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    modal.style.display = 'flex';
+    modal.setAttribute('aria-hidden', 'false');
+    const target = initialFocus || modal.querySelector(focusableSelector) || modal;
+    requestAnimationFrame(() => target.focus());
+}
+
+export function hideModalOverlay(modal) {
+    if (!modal) return;
+    modal.style.display = 'none';
+    modal.setAttribute('aria-hidden', 'true');
+    const previousFocus = modal._previousFocus;
+    modal._previousFocus = null;
+    if (previousFocus?.isConnected) previousFocus.focus();
 }
 
 export function bindModalClose(modal, { onClose, closeOnBackdrop = false } = {}) {
@@ -26,7 +62,32 @@ export function bindModalClose(modal, { onClose, closeOnBackdrop = false } = {})
         onClose(e);
     };
 
+    const keydownHandler = (event) => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            onClose(event);
+            return;
+        }
+        if (event.key !== 'Tab') return;
+        const focusable = [...modal.querySelectorAll(focusableSelector)];
+        if (!focusable.length) {
+            event.preventDefault();
+            modal.focus();
+            return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    };
+
     closeButtons.forEach(btn => btn.addEventListener('click', clickHandler));
+    modal.addEventListener('keydown', keydownHandler);
 
     let backdropHandler = null;
     if (closeOnBackdrop) {
@@ -40,6 +101,7 @@ export function bindModalClose(modal, { onClose, closeOnBackdrop = false } = {})
 
     return () => {
         closeButtons.forEach(btn => btn.removeEventListener('click', clickHandler));
+        modal.removeEventListener('keydown', keydownHandler);
         if (backdropHandler) {
             modal.removeEventListener('click', backdropHandler);
         }
@@ -58,17 +120,21 @@ function createDialogShell({ title = '', description = '' } = {}) {
     header.className = 'app-dialog__header';
 
     const titleElement = document.createElement('h2');
+    titleElement.id = `dialog-title-${crypto.randomUUID()}`;
     titleElement.className = 'app-dialog__title';
     titleElement.textContent = title;
     header.appendChild(titleElement);
+    dialog.setAttribute('aria-labelledby', titleElement.id);
 
     form.appendChild(header);
 
     if (description) {
         const descriptionElement = document.createElement('p');
+        descriptionElement.id = `dialog-description-${crypto.randomUUID()}`;
         descriptionElement.className = 'app-dialog__description';
         descriptionElement.textContent = description;
         form.appendChild(descriptionElement);
+        dialog.setAttribute('aria-describedby', descriptionElement.id);
     }
 
     const body = document.createElement('div');
@@ -116,7 +182,7 @@ export function showConfirmDialog({
         }, { once: true });
 
         dialog.showModal();
-        confirmButton.focus();
+        (danger ? cancelButton : confirmButton).focus();
     });
 }
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,5 +1,5 @@
 import { getTemplateContent } from './template.js';
-import { createModalOverlay, bindModalClose } from './modal.js';
+import { createModalOverlay, bindModalClose, hideModalOverlay, showModalOverlay } from './modal.js';
 
 export class SearchHandler {
     constructor(fileManager) {
@@ -314,12 +314,16 @@ export class SearchHandler {
 
     hideSearchOptions() {
         document.querySelector('.search-container')?.classList.remove('expanded');
-        if (this.searchModal) this.searchModal.style.display = 'none';
+        if (this.searchModal) hideModalOverlay(this.searchModal);
     }
 
     toggleSearchOptions() {
         if (this.searchModal) {
-            this.searchModal.style.display = this.searchModal.style.display === 'none' ? 'flex' : 'none';
+            if (this.searchModal.style.display === 'none') {
+                showModalOverlay(this.searchModal);
+            } else {
+                hideModalOverlay(this.searchModal);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- give overlay dialogs accessible names and modal semantics
- trap keyboard focus and close overlays consistently with Escape
- restore focus to the invoking control when overlays close
- label native confirm dialogs and focus Cancel for destructive actions

## Tests
- go test ./...
- go vet ./...
- node --check static/js/modal.js
- node --check static/js/gallery.js
- node --check static/js/search.js
- node --check static/js/file-editor.js
- node --check static/js/media-player.js
- git diff --check