### PR TITLE
fix: recover from frontend startup failures

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -57,7 +57,7 @@ class FileManagerApp {
         // Fetch config first
         this.config = await this.api.getConfig();
         if (!this.config) {
-            return; // Stop initialization if config fails
+            throw new Error('Failed to load the application configuration.');
         }
 
         // Update UI based on config
@@ -219,8 +219,51 @@ async function main() {
     await app.init();
 }
 
+function renderStartupError(error) {
+    console.error('Failed to initialize Pure Mania', error);
+    const root = document.getElementById('app-root') || document.body;
+    const panel = document.createElement('main');
+    panel.className = 'startup-error';
+    panel.setAttribute('role', 'alert');
+
+    const title = document.createElement('h1');
+    title.textContent = 'Pure Mania could not start';
+    const message = document.createElement('p');
+    message.textContent = navigator.onLine
+        ? 'Some application resources could not be loaded.'
+        : 'You appear to be offline. Check your connection and try again.';
+    panel.append(title, message);
+
+    if (Array.isArray(error?.failures)) {
+        const details = document.createElement('details');
+        const summary = document.createElement('summary');
+        summary.textContent = 'Failed resources';
+        const list = document.createElement('ul');
+        error.failures.forEach(({ url }) => {
+            const item = document.createElement('li');
+            item.textContent = url;
+            list.appendChild(item);
+        });
+        details.append(summary, list);
+        panel.appendChild(details);
+    }
+
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.className = 'btn btn-primary';
+    retry.textContent = 'Retry';
+    retry.addEventListener('click', () => window.location.reload());
+    panel.appendChild(retry);
+    root.replaceChildren(panel);
+    retry.focus();
+}
+
+function startApplication() {
+    void main().catch(renderStartupError);
+}
+
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', main, { once: true });
+    document.addEventListener('DOMContentLoaded', startApplication, { once: true });
 } else {
-    void main();
+    startApplication();
 }

--- a/static/js/template.js
+++ b/static/js/template.js
@@ -46,5 +46,12 @@ export function getTemplateContent(url) {
  * @param {string[]} urls - An array of template URLs to load.
  */
 export async function loadTemplates(urls) {
-  await Promise.all(urls.map(url => loadTemplate(url)));
+  const results = await Promise.allSettled(urls.map(url => loadTemplate(url)));
+  const failures = results.flatMap((result, index) => result.status === 'rejected' ? [{ url: urls[index], error: result.reason }] : []);
+  if (failures.length) {
+    const error = new Error(`Failed to load ${failures.length} application template${failures.length === 1 ? '' : 's'}`);
+    error.name = 'TemplateLoadError';
+    error.failures = failures;
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
- report every template that failed during startup
- treat configuration loading failures as initialization errors
- render an accessible startup error with offline guidance and Retry
- prevent rejected initialization promises from leaving a blank application

## Tests
- go test ./...
- go vet ./...
- node --check static/js/app.js
- node --check static/js/template.js
- git diff --check