### PR TITLE
feat: paginate and cancel file searches

### DIFF
--- a/handlers/search_handlers.go
+++ b/handlers/search_handlers.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"puremania/cache"
 	"puremania/types"
 	"puremania/utils"
 	"regexp"
@@ -18,16 +17,25 @@ import (
 	"time"
 )
 
+type searchRequest struct {
+	Term          string `json:"term"`
+	Path          string `json:"path"`
+	Scope         string `json:"scope"`
+	UseRegex      bool   `json:"useRegex"`
+	CaseSensitive bool   `json:"caseSensitive"`
+	Cursor        string `json:"cursor"`
+	Limit         int    `json:"limit"`
+}
+
+type searchPage struct {
+	Data       []types.FileInfo `json:"data"`
+	NextCursor string           `json:"nextCursor,omitempty"`
+	HasMore    bool             `json:"hasMore"`
+}
+
 // SearchFiles - 並列処理と細かいキャッシュキー使用
 func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Term          string `json:"term"`
-		Path          string `json:"path"`
-		Scope         string `json:"scope"`
-		UseRegex      bool   `json:"useRegex"`
-		CaseSensitive bool   `json:"caseSensitive"`
-		MaxResults    int    `json:"maxResults"`
-	}
+	var req searchRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		h.logger.Error("Failed to decode search request", "error", err)
@@ -40,8 +48,8 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.MaxResults <= 0 || req.MaxResults > 10000 {
-		req.MaxResults = 1000
+	if req.Limit <= 0 || req.Limit > 500 {
+		req.Limit = 100
 	}
 	if req.UseRegex {
 		pattern := req.Term
@@ -54,15 +62,6 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 細かいキャッシュキーを生成
-	cacheKey := h.generateSearchCacheKey(req.Term, req.Path, req.Scope, req.UseRegex, req.CaseSensitive, req.MaxResults)
-	if cached, found := cache.Get(h.cache, cacheKey); found {
-		if results, ok := cached.([]types.FileInfo); ok {
-			h.respondSuccess(w, results)
-			return
-		}
-	}
-
 	basePath, err := h.convertToPhysicalPath(req.Path)
 	if err != nil {
 		h.logger.Error("Invalid path for search", "path", req.Path, "error", err)
@@ -70,10 +69,8 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, searchErr := h.performSearch(r.Context(), req, basePath)
+	results, searchErr := h.performSearchPage(r.Context(), req, basePath)
 	if searchErr == nil {
-		// 結果をキャッシュ（検索結果は短めのTTL）
-		cache.Set(h.cache, cacheKey, results, int64(len(results)*200), time.Minute*2)
 		h.respondSuccess(w, results)
 	} else {
 		if searchErr == context.Canceled || searchErr == context.DeadlineExceeded {
@@ -82,6 +79,117 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("Search failed", "error", searchErr)
 		h.respondError(w, "Search failed", http.StatusInternalServerError)
 	}
+}
+
+func (h *Handler) performSearchPage(ctx context.Context, req searchRequest, basePath string) (searchPage, error) {
+	match, err := buildSearchMatcher(req)
+	if err != nil {
+		return searchPage{}, err
+	}
+	if req.Scope == "recursive" {
+		return h.searchRecursivePage(ctx, basePath, req.Cursor, req.Limit, match)
+	}
+	return h.searchCurrentPage(ctx, basePath, req.Cursor, req.Limit, match)
+}
+
+func buildSearchMatcher(req searchRequest) (func(string) bool, error) {
+	if req.UseRegex {
+		pattern := req.Term
+		if !req.CaseSensitive {
+			pattern = "(?i)" + pattern
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+		return re.MatchString, nil
+	}
+	term := req.Term
+	if !req.CaseSensitive {
+		term = strings.ToLower(term)
+	}
+	return func(name string) bool {
+		if req.CaseSensitive {
+			return strings.Contains(name, term)
+		}
+		return strings.Contains(strings.ToLower(name), term)
+	}, nil
+}
+
+func (h *Handler) searchFileInfo(path string, entry os.DirEntry) types.FileInfo {
+	var size int64
+	var modTime time.Time
+	if info, err := entry.Info(); err == nil {
+		size = info.Size()
+		modTime = info.ModTime()
+	}
+	mimeType := mediaTypeByPath(entry.Name())
+	return types.FileInfo{
+		Name: entry.Name(), Path: h.convertToVirtualPath(path), Size: size,
+		ModTime: modTime.Format(time.RFC3339), IsDir: entry.IsDir(), MimeType: mimeType,
+		IsEditable: utils.IsTextFile(mimeType) || utils.IsEditableByExtension(entry.Name()),
+	}
+}
+
+func finishSearchPage(results []types.FileInfo, limit int) searchPage {
+	hasMore := len(results) > limit
+	if hasMore {
+		results = results[:limit]
+	}
+	nextCursor := ""
+	if hasMore && len(results) > 0 {
+		nextCursor = results[len(results)-1].Path
+	}
+	return searchPage{Data: results, NextCursor: nextCursor, HasMore: hasMore}
+}
+
+func (h *Handler) searchCurrentPage(ctx context.Context, path, cursor string, limit int, match func(string) bool) (searchPage, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return searchPage{}, err
+	}
+	results := make([]types.FileInfo, 0, limit+1)
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return searchPage{}, err
+		}
+		fullPath := filepath.Join(path, entry.Name())
+		virtualPath := h.convertToVirtualPath(fullPath)
+		if virtualPath <= cursor || !match(entry.Name()) {
+			continue
+		}
+		results = append(results, h.searchFileInfo(fullPath, entry))
+		if len(results) > limit {
+			break
+		}
+	}
+	return finishSearchPage(results, limit), nil
+}
+
+func (h *Handler) searchRecursivePage(ctx context.Context, path, cursor string, limit int, match func(string) bool) (searchPage, error) {
+	results := make([]types.FileInfo, 0, limit+1)
+	err := filepath.WalkDir(path, func(filePath string, entry os.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			h.logger.Warn("Skipping path in recursive search", "path", filePath, "error", walkErr)
+			return nil
+		}
+		virtualPath := h.convertToVirtualPath(filePath)
+		if virtualPath <= cursor || !match(entry.Name()) {
+			return nil
+		}
+		results = append(results, h.searchFileInfo(filePath, entry))
+		if len(results) > limit {
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return searchPage{}, err
+	}
+	return finishSearchPage(results, limit), nil
 }
 
 func (h *Handler) performSearch(ctx context.Context, req struct {

--- a/handlers/search_handlers_test.go
+++ b/handlers/search_handlers_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"testing"
+
+	"puremania/types"
+)
+
+func TestFinishSearchPageUsesLastReturnedPathAsCursor(t *testing.T) {
+	results := []types.FileInfo{{Path: "/a"}, {Path: "/b"}, {Path: "/c"}}
+	page := finishSearchPage(results, 2)
+	if !page.HasMore || page.NextCursor != "/b" || len(page.Data) != 2 {
+		t.Fatalf("unexpected page: %#v", page)
+	}
+}
+
+func TestBuildSearchMatcherRejectsInvalidRegex(t *testing.T) {
+	_, err := buildSearchMatcher(searchRequest{Term: "[", UseRegex: true})
+	if err == nil {
+		t.Fatal("expected invalid regular expression to fail")
+	}
+}
+
+func TestBuildSearchMatcherHonorsCaseSensitivity(t *testing.T) {
+	insensitive, err := buildSearchMatcher(searchRequest{Term: "track"})
+	if err != nil || !insensitive("Track.MP3") {
+		t.Fatalf("case-insensitive matcher failed: %v", err)
+	}
+	sensitive, err := buildSearchMatcher(searchRequest{Term: "track", CaseSensitive: true})
+	if err != nil || sensitive("Track.MP3") {
+		t.Fatalf("case-sensitive matcher failed: %v", err)
+	}
+}

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -651,16 +651,15 @@ export class ApiClient {
         return result.data;
     }
 
-    async search(term, path, options, limit, offset) {
+    async search(term, path, options, limit, cursor = '', signal) {
         const body = {
             term: term,
             path: path,
             useRegex: options.useRegex,
             caseSensitive: options.caseSensitive,
             scope: options.scope,
-            maxResults: 10000, // This seems high, but matching original logic
-            offset: offset,
-            limit: limit
+            cursor,
+            limit
         };
 
         const response = await fetch('/api/search', {
@@ -668,7 +667,8 @@ export class ApiClient {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(body)
+            body: JSON.stringify(body),
+            signal
         });
         
         return await response.json();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -11,6 +11,11 @@ export class SearchHandler {
         this.currentPage = 0;
         this.pageSize = 100;
         this.totalResults = 0;
+        this.searchRequestId = 0;
+        this.searchController = null;
+        this.cursorHistory = [''];
+        this.nextCursor = '';
+        this.hasMore = false;
         this.sortField = 'name';
         this.sortDirection = 'asc';
         this.isInSearchMode = false;
@@ -379,12 +384,23 @@ export class SearchHandler {
         }
         this.lastSearchTerm = searchTerm;
         this.currentPage = page;
+        if (page === 0) this.cursorHistory = [''];
+        const cursor = this.cursorHistory[page] ?? '';
+        const requestId = ++this.searchRequestId;
+        this.searchController?.abort();
+        const controller = new AbortController();
+        this.searchController = controller;
         this.fileManager.ui.showLoading();
         try {
-            const result = await this.fileManager.api.search(searchTerm, this.fileManager.router.getCurrentPath(), this.searchOptions, this.pageSize, page * this.pageSize);
+            const result = await this.fileManager.api.search(searchTerm, this.fileManager.router.getCurrentPath(), this.searchOptions, this.pageSize, cursor, controller.signal);
+            if (requestId !== this.searchRequestId || controller.signal.aborted) return;
             if (result && result.success) {
-                this.lastSearchResults = this.sortResults(result.data || [], this.sortField, this.sortDirection);
-                this.totalResults = this.lastSearchResults.length;
+                const searchPage = result.data || {};
+                this.lastSearchResults = this.sortResults(searchPage.data || [], this.sortField, this.sortDirection);
+                this.nextCursor = searchPage.nextCursor || '';
+                this.hasMore = Boolean(searchPage.hasMore);
+                if (this.hasMore) this.cursorHistory[page + 1] = this.nextCursor;
+                this.cursorHistory.length = this.hasMore ? page + 2 : page + 1;
                 if (this.fileManager.ui.viewMode === 'masonry') {
                     this.fileManager.ui.viewMode = 'grid';
                 }
@@ -393,6 +409,8 @@ export class SearchHandler {
                 this.fileManager.ui.showToast('Search Error', result ? result.message : 'Unknown error', 'error');
             }
         } catch (error) {
+            if (error.name === 'AbortError') return;
+            if (requestId !== this.searchRequestId) return;
             this.fileManager.ui.showToast('Search Error', 'Failed to perform search', 'error');
         } finally {
             this.fileManager.ui.hideLoading();
@@ -402,14 +420,7 @@ export class SearchHandler {
     async refreshSearchResults() {
         if (!this.isInSearchMode || !this.lastSearchTerm) return;
         try {
-            const result = await this.fileManager.api.search(this.lastSearchTerm, this.fileManager.router.getCurrentPath(), this.searchOptions, this.pageSize, 0);
-            if (result && result.success) {
-                this.lastSearchResults = this.sortResults(result.data || [], this.sortField, this.sortDirection);
-                this.totalResults = this.lastSearchResults.length;
-                const totalPages = Math.ceil(this.lastSearchResults.length / this.pageSize);
-                if (this.currentPage >= totalPages) this.currentPage = Math.max(0, totalPages - 1);
-                this.displaySearchResults(this.lastSearchResults, this.lastSearchTerm, this.currentPage);
-            }
+            await this.performSearch(this.currentPage);
         } catch (error) {
             console.error('Error refreshing search results:', error);
         }
@@ -421,17 +432,15 @@ export class SearchHandler {
         container.innerHTML = '';
         results = results || [];
         const startIndex = page * this.pageSize;
-        const endIndex = Math.min(startIndex + this.pageSize, results.length);
-        const pageResults = results.slice(startIndex, endIndex);
-        const totalPages = Math.ceil(results.length / this.pageSize);
+        const endIndex = startIndex + results.length;
 
         const header = document.createElement('div');
         header.className = 'search-results-header';
         const headerTemplate = getTemplateContent('/static/templates/components/search_results_header.html');
-        headerTemplate.querySelector('.search-results-count div').textContent = `Search Results for "${searchTerm}" (${results.length} found)`;
-        if (results.length > this.pageSize) {
-            headerTemplate.querySelector('.pagination-info').textContent = `[${page + 1}/${totalPages}] Showing ${startIndex + 1}-${endIndex} of ${results.length} results`;
-        }
+        headerTemplate.querySelector('.search-results-count div').textContent = `Search Results for "${searchTerm}"`;
+        headerTemplate.querySelector('.pagination-info').textContent = results.length
+            ? `Page ${page + 1} · Showing ${startIndex + 1}-${endIndex}${this.hasMore ? '+' : ''}`
+            : `Page ${page + 1}`;
         const options = [];
         if (this.searchOptions.useRegex) options.push('REGEX');
         if (this.searchOptions.caseSensitive) options.push('CASE-SENSITIVE');
@@ -440,7 +449,7 @@ export class SearchHandler {
             headerTemplate.querySelector('.search-options-display').textContent = `[${options.join(', ')}]`;
         }
         header.appendChild(headerTemplate);
-        header.querySelector('.search-controls').appendChild(this.createPaginationControls(page, totalPages));
+        header.querySelector('.search-controls').appendChild(this.createPaginationControls(page, this.hasMore));
         container.appendChild(header);
         header.querySelector('.search-back-btn').addEventListener('click', () => this.exitSearchMode());
 
@@ -458,17 +467,17 @@ export class SearchHandler {
         }
 
         this.fileManager.ui.renderSearchResultsFiles(
-            pageResults,
+            results,
             container,
             this.sortField,
             this.sortDirection,
             (field) => this.setSort(field)
         );
 
-        if (totalPages > 1) {
+        if (page > 0 || this.hasMore) {
             const footerPagination = document.createElement('div');
             footerPagination.className = 'search-pagination-footer';
-            footerPagination.appendChild(this.createPaginationControls(page, totalPages));
+            footerPagination.appendChild(this.createPaginationControls(page, this.hasMore));
             container.appendChild(footerPagination);
         }
         container.scrollTop = 0;
@@ -479,6 +488,9 @@ export class SearchHandler {
         this.lastSearchResults = null;
         this.lastSearchTerm = '';
         this.currentPage = 0;
+        this.searchController?.abort();
+        this.searchController = null;
+        this.cursorHistory = [''];
         const searchInput = document.querySelector('.search-input');
         if (searchInput) searchInput.value = '';
         this.isCdMode = false;
@@ -493,8 +505,8 @@ export class SearchHandler {
         }
     }
 
-    createPaginationControls(currentPage, totalPages) {
-        if (totalPages <= 1) return document.createDocumentFragment();
+    createPaginationControls(currentPage, hasMore) {
+        if (currentPage === 0 && !hasMore) return document.createDocumentFragment();
         const controls = document.createElement('div');
         controls.className = 'pagination-controls';
         
@@ -507,40 +519,12 @@ export class SearchHandler {
             return btn;
         };
 
-        const createPageBtn = (text, page) => {
-            const btn = document.createElement('button');
-            btn.className = 'page-btn';
-            btn.textContent = text;
-            btn.addEventListener('click', () => this.performSearch(page));
-            return btn;
-        };
-
         controls.appendChild(createNavBtn('← Previous', currentPage - 1, currentPage === 0));
-        
-        const pageNumbers = document.createElement('div');
-        pageNumbers.className = 'page-numbers';
-        
-        const startPage = Math.max(0, currentPage - 2);
-        const endPage = Math.min(totalPages - 1, currentPage + 2);
-
-        if (startPage > 0) {
-            pageNumbers.appendChild(createPageBtn('1', 0));
-            if (startPage > 1) pageNumbers.insertAdjacentHTML('beforeend', '<span class="page-ellipsis">...</span>');
-        }
-
-        for (let i = startPage; i <= endPage; i++) {
-            const btn = createPageBtn(i + 1, i);
-            if (i === currentPage) btn.classList.add('active');
-            pageNumbers.appendChild(btn);
-        }
-
-        if (endPage < totalPages - 1) {
-            if (endPage < totalPages - 2) pageNumbers.insertAdjacentHTML('beforeend', '<span class="page-ellipsis">...</span>');
-            pageNumbers.appendChild(createPageBtn(totalPages, totalPages - 1));
-        }
-
-        controls.appendChild(pageNumbers);
-        controls.appendChild(createNavBtn('Next →', currentPage + 1, currentPage === totalPages - 1));
+        const pageLabel = document.createElement('span');
+        pageLabel.className = 'pagination-info';
+        pageLabel.textContent = `Page ${currentPage + 1}`;
+        controls.appendChild(pageLabel);
+        controls.appendChild(createNavBtn('Next →', currentPage + 1, !hasMore));
         return controls;
     }
 


### PR DESCRIPTION
## Summary
- return stable cursor-based search pages capped at 500 entries
- stop filesystem traversal after collecting one page plus a continuation marker
- abort superseded browser searches and reject stale responses
- replace client-side 10,000-result pagination with Previous/Next cursors
- add matcher and cursor unit tests

## Tests
- go test ./...
- go vet ./...
- node --check static/js/api.js
- node --check static/js/search.js
- git diff --check