### PR TITLE
feat: prepare ZIP downloads server-side

### DIFF
--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"archive/zip"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -21,6 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gorilla/mux"
 
 	"github.com/mholt/archives"
 )
@@ -768,7 +771,7 @@ func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// DownloadZip - 並列処理でZIPストリーミング配信
+// DownloadZip prepares a validated archive before returning a normal download URL.
 func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 	var req types.BatchPathsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -782,27 +785,80 @@ func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/zip")
-	w.Header().Set("Content-Disposition", "attachment; filename=\"files.zip\"")
-	w.Header().Set("Transfer-Encoding", "chunked")
-
-	// io.Pipeでストリーミング
-	pr, pw := io.Pipe()
-
-	// zip.Writer is inherently serial. Keeping this work out of the shared
-	// worker pool avoids parent tasks waiting on child tasks in that same pool.
-	go func() {
-		ctx, cancel := context.WithTimeout(r.Context(), time.Duration(h.config.ZipTimeout)*time.Second)
-		defer cancel()
-		if err := h.createZipArchive(ctx, pw, req.Paths); err != nil {
-			_ = pw.CloseWithError(err)
-			return
+	tmp, err := os.CreateTemp("", "puremania-download-*.zip")
+	if err != nil {
+		h.respondError(w, "Cannot prepare archive", http.StatusInternalServerError)
+		return
+	}
+	tmpPath := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if closeErr := tmp.Close(); closeErr != nil {
+			h.logger.Warn("Failed to close prepared zip", "error", closeErr)
 		}
-		_ = pw.Close()
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
 	}()
 
-	// ストリーミング出力
-	_, _ = io.Copy(w, pr)
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(h.config.ZipTimeout)*time.Second)
+	defer cancel()
+	if err := h.createZipArchive(ctx, tmp, req.Paths); err != nil {
+		h.logger.Error("Failed to prepare zip", "error", err)
+		h.respondError(w, "Cannot create archive", http.StatusInternalServerError)
+		return
+	}
+	if err := tmp.Sync(); err != nil {
+		h.respondError(w, "Cannot finalize archive", http.StatusInternalServerError)
+		return
+	}
+
+	tokenBytes := make([]byte, 24)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		h.respondError(w, "Cannot create download token", http.StatusInternalServerError)
+		return
+	}
+	token := hex.EncodeToString(tokenBytes)
+	expiresAt := time.Now().Add(time.Hour)
+	h.zipDownloads.Store(token, preparedZip{path: tmpPath, expiresAt: expiresAt})
+	removeTemp = false
+	time.AfterFunc(time.Until(expiresAt), func() {
+		if value, loaded := h.zipDownloads.LoadAndDelete(token); loaded {
+			_ = os.Remove(value.(preparedZip).path)
+		}
+	})
+	h.respondSuccess(w, map[string]string{"downloadUrl": "/api/files/download-zip/" + token})
+}
+
+func (h *Handler) DownloadPreparedZip(w http.ResponseWriter, r *http.Request) {
+	token := mux.Vars(r)["token"]
+	value, ok := h.zipDownloads.Load(token)
+	if !ok {
+		h.respondError(w, "Download not found or expired", http.StatusNotFound)
+		return
+	}
+	prepared := value.(preparedZip)
+	if time.Now().After(prepared.expiresAt) {
+		h.zipDownloads.Delete(token)
+		_ = os.Remove(prepared.path)
+		h.respondError(w, "Download expired", http.StatusGone)
+		return
+	}
+	file, err := os.Open(prepared.path)
+	if err != nil {
+		h.respondError(w, "Cannot open archive", http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		h.respondError(w, "Cannot inspect archive", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", "attachment; filename=\"files.zip\"")
+	w.Header().Set("Cache-Control", "private, no-store")
+	http.ServeContent(w, r, "files.zip", info.ModTime(), file)
 }
 
 type maxBytesWriter struct {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -17,12 +17,18 @@ const (
 
 // Handler はAPIハンドラーの依存関係を保持
 type Handler struct {
-	config      *types.Config
-	cache       *types.TTLCache
-	workerPool  *types.WorkerPool
-	logger      *slog.Logger
-	uploadLocks [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
-	uploadGate  chan struct{}   // bounds concurrent disk writes across sessions
+	config       *types.Config
+	cache        *types.TTLCache
+	workerPool   *types.WorkerPool
+	logger       *slog.Logger
+	uploadLocks  [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
+	uploadGate   chan struct{}   // bounds concurrent disk writes across sessions
+	zipDownloads sync.Map        // token -> preparedZip; entries expire after download preparation
+}
+
+type preparedZip struct {
+	path      string
+	expiresAt time.Time
 }
 
 func (h *Handler) sessionMutex(id string) *sync.Mutex {

--- a/handlers/zip_download_test.go
+++ b/handlers/zip_download_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"puremania/types"
+)
+
+func TestDownloadPreparedZipServesStoredArchive(t *testing.T) {
+	h := NewHandler(&types.Config{StorageDir: t.TempDir()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	path := t.TempDir() + "/prepared.zip"
+	want := []byte("prepared archive")
+	if err := os.WriteFile(path, want, 0600); err != nil {
+		t.Fatal(err)
+	}
+	h.zipDownloads.Store("token", preparedZip{path: path, expiresAt: time.Now().Add(time.Minute)})
+
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/files/download-zip/token", nil), map[string]string{"token": "token"})
+	res := httptest.NewRecorder()
+	h.DownloadPreparedZip(res, req)
+	if res.Code != http.StatusOK || res.Body.String() != string(want) {
+		t.Fatalf("status=%d body=%q", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Disposition"); got != "attachment; filename=\"files.zip\"" {
+		t.Fatalf("Content-Disposition = %q", got)
+	}
+}
+
+func TestDownloadPreparedZipRejectsExpiredToken(t *testing.T) {
+	h := NewHandler(&types.Config{StorageDir: t.TempDir()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	path := t.TempDir() + "/expired.zip"
+	if err := os.WriteFile(path, []byte("expired"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	h.zipDownloads.Store("expired", preparedZip{path: path, expiresAt: time.Now().Add(-time.Second)})
+
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/files/download-zip/expired", nil), map[string]string{"token": "expired"})
+	res := httptest.NewRecorder()
+	h.DownloadPreparedZip(res, req)
+	if res.Code != http.StatusGone {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusGone)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -178,6 +178,7 @@ func main() {
 	api.HandleFunc("/files/download", handler.DownloadFile).Methods("GET")
 	api.HandleFunc("/files/content", handler.GetFileContent).Methods("GET")
 	api.HandleFunc("/files/download-zip", handler.DownloadZip).Methods("POST")
+	api.HandleFunc("/files/download-zip/{token}", handler.DownloadPreparedZip).Methods("GET")
 	api.HandleFunc("/files/save", handler.SaveFile).Methods("POST")
 	api.HandleFunc("/files/delete", handler.DeleteMultipleFiles).Methods("POST")
 	api.HandleFunc("/files/mkdir", handler.CreateDirectory).Methods("POST")

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -499,75 +499,23 @@ export class ApiClient {
                     paths: Array.from(this.app.selectedFiles)
                 })
             });
-            
-            if (response.ok) {
-                const contentLength = response.headers.get('content-length');
-                const successfulFiles = parseInt(response.headers.get('X-Zip-Successful-Files') || '0');
-                const failedFiles = parseInt(response.headers.get('X-Zip-Failed-Files') || '0');
-                
-                const reader = response.body.getReader();
-                const chunks = [];
-                let receivedLength = 0;
-                
-                while (true) {
-                    const { done, value } = await reader.read();
-                    
-                    if (done) {
-                        break;
-                    }
-                    
-                    chunks.push(value);
-                    receivedLength += value.length;
-                    
-                    if (contentLength) {
-                        const percentage = (receivedLength / parseInt(contentLength)) * 100;
-                        this.app.progressManager.updateProgress({
-                            currentFile: 'Downloading archive...',
-                            percentage: percentage,
-                            processed: Math.floor((percentage / 100) * this.app.selectedFiles.size),
-                            total: this.app.selectedFiles.size,
-                            status: `${Math.round(percentage)}% downloaded`
-                        });
-                    }
-                }
-                
-                const blob = new Blob(chunks);
-                
-                this.app.progressManager.updateProgress({
-                    currentFile: 'Saving files...',
-                    percentage: 100,
-                    processed: this.app.selectedFiles.size,
-                    total: this.app.selectedFiles.size,
-                    status: 'Complete'
-                });
-                
-                const url = window.URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = 'files.zip';
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                
-                // Delay revoking the object URL to allow iOS Safari time to process the download
-                setTimeout(() => {
-                    window.URL.revokeObjectURL(url);
-                }, 30000); // 30 seconds delay
-                
-                let message = `Downloaded ${successfulFiles} files successfully`;
-                if (failedFiles > 0) {
-                    message += `, ${failedFiles} files failed to be included.`;
-                }
-                this.app.ui.showToast('Success', message, 'success');
-                this.app.progressManager.hide();
-
-            } else {
-                const error = await response.json();
-                this.notifyApiError(this.getApiErrorMessage(error, 'Failed to create zip archive'));
-                this.app.progressManager.hide();
+            const result = await response.json().catch(() => null);
+            if (!response.ok || !result?.success || !result.data?.downloadUrl) {
+                throw new Error(this.getApiErrorMessage(result, 'Failed to create zip archive'));
             }
+
+            this.app.progressManager.updateProgress({
+                currentFile: 'Archive ready',
+                percentage: 100,
+                processed: this.app.selectedFiles.size,
+                total: this.app.selectedFiles.size,
+                status: 'Starting browser download'
+            });
+            this.app.ui.showToast('Archive ready', 'The download has started.', 'success');
+            this.app.progressManager.hide();
+            window.location.assign(result.data.downloadUrl);
         } catch (error) {
-            this.notifyApiError('Failed to download files', { error, context: 'downloading files' });
+            this.notifyApiError(this.getApiErrorMessage(error, 'Failed to download files'), { error, context: 'downloading files' });
             this.app.progressManager.hide();
         }
     }


### PR DESCRIPTION
## Summary
- prepare and validate ZIP archives before returning a download URL
- serve prepared archives through a range-capable normal GET endpoint
- expire random download tokens and remove temporary archives
- remove browser-side buffering and Blob duplication for large ZIP files
- test prepared and expired download behavior

## Tests
- go test ./...
- go vet ./...
- node --check static/js/api.js
- git diff --check