### PR TITLE
refactor: centralize upload runtime state

### DIFF
--- a/static/js/progress.js
+++ b/static/js/progress.js
@@ -3,7 +3,6 @@ import { getTemplateContent } from './template.js';
 export class ProgressManager {
     constructor() {
         this.progressOverlay = null;
-        this.currentUpload = null;
         this.isCompleted = false;
         this.startTime = null;
         this.timerInterval = null;
@@ -201,7 +200,6 @@ export class ProgressManager {
         if (this.progressOverlay) {
             this.progressOverlay.style.display = 'none';
         }
-        this.currentUpload = null;
         this.isCompleted = false;
         this.isMinimized = false;
         this.stopTimer();
@@ -237,10 +235,4 @@ export class ProgressManager {
         }
     }
 
-    setCurrentUpload(upload) {
-        this.currentUpload = upload;
-        if (upload) {
-            this.isCompleted = false;
-        }
-    }
 }

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -4,10 +4,10 @@ export class UploadPageHandler {
     constructor(app) {
         this.app = app;
         this.active = false;
-        this.interval = null;
         this.selectedKeys = new Set();
         this.polling = false;
         this.timer = null;
+        this.refreshController = null;
         this.onJobsChanged = () => this.refresh();
     }
 
@@ -23,6 +23,8 @@ export class UploadPageHandler {
         if (!this.active) return;
         this.active = false;
         clearTimeout(this.timer);
+        this.refreshController?.abort();
+        this.refreshController = null;
         window.removeEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
         document.querySelector('.breadcrumbs')?.style.removeProperty('display');
     }
@@ -30,10 +32,15 @@ export class UploadPageHandler {
     async refresh() {
         if (!this.active || this.polling) return;
         this.polling = true;
+        const controller = new AbortController();
+        this.refreshController = controller;
         try {
-            const jobs = await this.app.uploader.listJobs();
-            if (this.active) this.render(jobs);
+            const jobs = await this.app.uploader.listJobs(controller.signal);
+            if (this.active && !controller.signal.aborted) this.render(jobs);
+        } catch (error) {
+            if (error.name !== 'AbortError') console.error('Failed to refresh uploads', error);
         } finally {
+            if (this.refreshController === controller) this.refreshController = null;
             this.polling = false;
             if (this.active) this.timer = setTimeout(() => this.refresh(), 3000);
         }

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -17,6 +17,19 @@ const pause = (ms, signal) => new Promise((resolve, reject) => {
 });
 const yieldToBrowser = () => new Promise(resolve => setTimeout(resolve, 0));
 
+async function mapWithConcurrency(items, limit, mapper) {
+    const results = new Array(items.length);
+    let nextIndex = 0;
+    const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (nextIndex < items.length) {
+            const index = nextIndex++;
+            results[index] = await mapper(items[index], index);
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
 class AdaptiveUploadController {
     constructor() {
         this.target = MIN_CONCURRENT_FILES;
@@ -257,7 +270,7 @@ export class Uploader {
         input.click();
     }
 
-    async listJobs() {
+    async listJobs(signal) {
         let records = [];
         try { records = await this.store.getAll(); } catch (_) { return []; }
         // /system/uploads is a client-side route, not a writable virtual path.
@@ -265,19 +278,20 @@ export class Uploader {
         // continue as duplicate uploads or remain misleading in this list.
         const invalidRouteRecords = records.filter(record => record.destination === '/system/uploads');
         if (invalidRouteRecords.length) {
-            await Promise.all(invalidRouteRecords.map(record => this.discardJob(record.key)));
+            await mapWithConcurrency(invalidRouteRecords, 6, record => this.discardJob(record.key));
             records = records.filter(record => record.destination !== '/system/uploads');
         }
-        const jobs = await Promise.all(records.map(async record => {
+        const jobs = await mapWithConcurrency(records, 6, async record => {
             try {
-                const status = await this.apiJSON(record.url);
+                const status = await this.apiJSON(record.url, { signal });
                 const active = this.activeUploadSession && this.progress.has(record.key);
                 return { ...record, uploadedBytes: status.uploadedBytes, totalBytes: status.totalBytes, completed: status.completed, state: status.completed ? 'completed' : active ? 'active' : 'paused' };
             } catch (error) {
+                if (error.name === 'AbortError') throw error;
                 if (error.status === 404) { await this.store.remove(record.key); return null; }
                 return { ...record, uploadedBytes: record.uploadedBytes || 0, totalBytes: record.size, state: 'offline' };
             }
-        }));
+        });
         return jobs.filter(Boolean);
     }
 
@@ -432,7 +446,6 @@ export class Uploader {
         }
         const session = this.createUploadSession();
         this.activeUploadSession = session;
-        this.app.progressManager.setCurrentUpload(session);
         const destination = destinationOverride || this.app.router.getCurrentPath();
         this.progress.clear();
         document.querySelector('.upload-area')?.classList.add('uploading');
@@ -471,7 +484,6 @@ export class Uploader {
         } finally {
             document.querySelector('.upload-area')?.classList.remove('uploading');
             if (this.activeUploadSession === session) this.activeUploadSession = null;
-            if (this.app.progressManager.currentUpload === session) this.app.progressManager.setCurrentUpload(null);
             this.notifyJobsChanged();
         }
     }


### PR DESCRIPTION
## Summary
- keep active upload ownership exclusively in Uploader
- make ProgressManager a presentation-only progress surface
- cap saved-session status requests at six concurrent operations
- abort upload-page refresh requests when leaving the route

## Tests
- go test ./...
- go vet ./...
- node --check static/js/uploader.js
- node --check static/js/progress.js
- node --check static/js/upload-page.js
- git diff --check