### PR TITLE
refactor: derive file selection from state

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -16,7 +16,7 @@ import { loadTemplates } from './template.js';
 class FileManagerApp {
     constructor() {
         this.selectedFiles = new Set();
-        this.lastSelectedIndex = -1;
+        this.selectionAnchorPath = null;
         this.config = {};
         this.directoryScrollPositions = new Map();
         this.renderedDirectoryPath = null;
@@ -160,13 +160,15 @@ class FileManagerApp {
         }
     }
 
-    clearSelection() {
-        document.querySelectorAll('.file-item.selected, .masonry-item.selected, .video-card.selected').forEach(item => {
-            item.classList.remove('selected');
-        });
-        this.selectedFiles.clear();
-        this.lastSelectedIndex = -1;
+    setSelection(paths, anchorPath = this.selectionAnchorPath) {
+        this.selectedFiles = new Set(paths);
+        this.selectionAnchorPath = anchorPath;
+        this.ui.syncSelectionClasses();
         this.ui.updateToolbar();
+    }
+
+    clearSelection() {
+        this.setSelection([], null);
     }
 
     updateStorageInfo(result) {

--- a/static/js/events.js
+++ b/static/js/events.js
@@ -227,41 +227,34 @@ export class EventHandler {
         }
 
         const fileItems = Array.from(document.querySelectorAll('.file-item, .masonry-item, .video-card'));
+        const anchorIndex = fileItems.findIndex(item => item.dataset.path === this.app.selectionAnchorPath);
         const currentIndex = fileItems.indexOf(fileItem);
+        let nextSelection = new Set(this.app.selectedFiles);
+        let nextAnchor = this.app.selectionAnchorPath;
         
-        if (event.shiftKey && this.app.lastSelectedIndex !== -1 && this.app.lastSelectedIndex !== currentIndex) {
-            this.app.clearSelection();
-            
-            const start = Math.min(this.app.lastSelectedIndex, currentIndex);
-            const end = Math.max(this.app.lastSelectedIndex, currentIndex);
-            
+        if (event.shiftKey && anchorIndex !== -1 && anchorIndex !== currentIndex) {
+            nextSelection = new Set();
+            const start = Math.min(anchorIndex, currentIndex);
+            const end = Math.max(anchorIndex, currentIndex);
             for (let i = start; i <= end; i++) {
                 if (i < fileItems.length) {
-                    const item = fileItems[i];
-                    const itemPath = item.dataset.path;
-                    this.app.selectedFiles.add(itemPath);
-                    item.classList.add('selected');
+                    nextSelection.add(fileItems[i].dataset.path);
                 }
             }
         } 
         else if (event.ctrlKey || event.metaKey) {
             if (isSelected) {
-                this.app.selectedFiles.delete(path);
-                fileItem.classList.remove('selected');
+                nextSelection.delete(path);
             } else {
-                this.app.selectedFiles.add(path);
-                fileItem.classList.add('selected');
-                this.app.lastSelectedIndex = currentIndex;
+                nextSelection.add(path);
+                nextAnchor = path;
             }
         } 
         else {
-            this.app.clearSelection();
-            this.app.selectedFiles.add(path);
-            fileItem.classList.add('selected');
-            this.app.lastSelectedIndex = currentIndex;
+            nextSelection = new Set([path]);
+            nextAnchor = path;
         }
-        
-        this.app.ui.updateToolbar();
+        this.app.setSelection(nextSelection, nextAnchor);
     }
 
     handleFileDoubleClick(fileItem) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -68,7 +68,9 @@ export class UIManager {
 
     syncSelectionClasses(container = document) {
         container.querySelectorAll('.file-item, .masonry-item, .video-card').forEach(item => {
-            item.classList.toggle('selected', this.app.selectedFiles.has(item.dataset.path));
+            const selected = this.app.selectedFiles.has(item.dataset.path);
+            item.classList.toggle('selected', selected);
+            item.setAttribute('aria-selected', String(selected));
         });
     }
 


### PR DESCRIPTION
## Summary
- make the selected-path Set the only file-selection state
- derive selected classes and aria-selected from application state
- replace the fragile numeric selection index with an anchor path
- preserve Shift selection across sorting by resolving the anchor in the current view

## Tests
- go test ./...
- go vet ./...
- node --check static/js/app.js
- node --check static/js/ui.js
- node --check static/js/events.js
- git diff --check