### PR TITLE
refactor: publish frontend domain events

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -133,6 +133,7 @@ export class ApiClient {
             if (onSuccess) {
                 await onSuccess(result);
             }
+            this.app.emit('files-mutated', { endpoint, payload });
             return { success: true, result };
         } catch (error) {
             this.notifyApiError(errorMessage, { error, context: logContext });
@@ -340,6 +341,7 @@ export class ApiClient {
                     this.app.ui.showToast('Success', message, 'success');
                 }
                 await this.refreshCurrentDirectory([targetDir], true);
+                this.app.emit('files-mutated', { endpoint: '/api/files/move', count: successCount });
             } else {
                 this.app.ui.showToast('Error', 'All items failed to move', 'error');
             }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -22,6 +22,7 @@ class FileManagerApp {
         this.renderedDirectoryPath = null;
         this.editRequestId = 0;
         this.isPC = !/Mobi|Android/i.test(navigator.userAgent);
+        this.eventBus = new EventTarget();
 
         // Initialize modules that don't depend on templates in their constructor
         this.router = new Router();
@@ -39,6 +40,12 @@ class FileManagerApp {
         this.searchHandler = new SearchHandler(this);
         this.aria2cPageHandler = new Aria2cPageHandler(this);
         this.uploadPageHandler = new UploadPageHandler(this);
+    }
+
+    emit(type, detail = {}, { cancelable = false } = {}) {
+        const event = new CustomEvent(type, { detail, cancelable });
+        this.eventBus.dispatchEvent(event);
+        return event;
     }
 
     async init() {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -16,6 +16,7 @@ export class SearchHandler {
         this.cursorHistory = [''];
         this.nextCursor = '';
         this.hasMore = false;
+        this.refreshTimer = null;
         this.sortField = 'name';
         this.sortDirection = 'asc';
         this.isInSearchMode = false;
@@ -45,39 +46,19 @@ export class SearchHandler {
     }
 
     setupFileOperationListeners() {
-        const api = this.fileManager.api;
-        const ui = this.fileManager.ui;
-        const originalMethods = {
-            deleteFile: api.deleteFile.bind(api),
-            renameFile: api.renameFile.bind(api),
-            moveFile: api.moveFile.bind(api),
-            createNewFile: api.createNewFile.bind(api),
-            createNewFolder: api.createNewFolder.bind(api),
-            setViewMode: ui.setViewMode.bind(ui)
-        };
-
-        const hook = (originalFn) => async (...args) => {
-            const result = await originalFn(...args);
+        this.fileManager.eventBus.addEventListener('files-mutated', () => {
             if (this.isInSearchMode && this.lastSearchTerm) {
-                setTimeout(() => this.refreshSearchResults(), 100);
+                clearTimeout(this.refreshTimer);
+                this.refreshTimer = setTimeout(() => this.refreshSearchResults(), 100);
             }
-            return result;
-        };
-
-        api.deleteFile = hook(originalMethods.deleteFile);
-        api.renameFile = hook(originalMethods.renameFile);
-        api.moveFile = hook(originalMethods.moveFile);
-        api.createNewFile = hook(originalMethods.createNewFile);
-        api.createNewFolder = hook(originalMethods.createNewFolder);
-
-        ui.setViewMode = (mode) => {
+        });
+        this.fileManager.eventBus.addEventListener('view-change-requested', event => {
             if (this.isInSearchMode && this.lastSearchResults && this.lastSearchTerm) {
-                ui.viewMode = mode;
+                event.preventDefault();
+                this.fileManager.ui.viewMode = event.detail.mode;
                 this.redisplayResults(this.currentPage);
-            } else {
-                originalMethods.setViewMode(mode);
             }
-        };
+        });
     }
 
     bindEvents() {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -563,6 +563,8 @@ export class UIManager {
     }
 
     setViewMode(mode) {
+        const event = this.app.emit('view-change-requested', { mode }, { cancelable: true });
+        if (event.defaultPrevented) return;
         this.viewMode = mode;
         this.displayFiles(this.currentFiles);
         this.app.uploader.bindUploadEvents();


### PR DESCRIPTION
## Summary
- add an explicit application event bus for domain changes
- publish successful file mutations instead of monkey-patching API methods
- let search subscribe to mutation events with debounced refresh
- route view changes through a cancellable event without replacing UI methods

## Tests
- go test ./...
- go vet ./...
- node --check static/js/app.js
- node --check static/js/api.js
- node --check static/js/ui.js
- node --check static/js/search.js
- git diff --check