### PR TITLE
feat: revalidate cached directories in background

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -143,11 +143,11 @@ export class ApiClient {
         }
     }
 
-    async getFiles(path, signal) {
+    async getFiles(path, { signal = null, useCache = true, detailed = false } = {}) {
         try {
             const headers = {};
             const etag = this.directoryEtags.get(path);
-            if (etag && this.directoryCache.has(path)) {
+            if (useCache && etag && this.directoryCache.has(path)) {
                 headers['If-None-Match'] = etag;
             }
 
@@ -157,7 +157,8 @@ export class ApiClient {
                 console.log(`Content for ${path} not modified. Using cache.`);
                 const cached = this.directoryCache.get(path);
                 if (cached) cached.usedAt = Date.now();
-                return cached?.files || null;
+                const response = { files: cached?.files || [], notModified: true, error: null };
+                return detailed ? response : response.files;
             }
 
             if (!response.ok) {
@@ -171,14 +172,15 @@ export class ApiClient {
             if (result.success) {
                 const files = result.data || [];
                 this.cacheDirectory(path, newEtag || '', files);
-                return files;
+                const response = { files, notModified: false, error: null };
+                return detailed ? response : files;
             } else {
                 throw new Error(result.message || 'API returned success:false');
             }
         } catch (error) {
             if (error.name === 'AbortError') throw error;
             console.error(`Error in getFiles for path ${path}:`, error);
-            return null;
+            return detailed ? { files: null, notModified: false, error } : null;
         }
     }
 
@@ -187,29 +189,47 @@ export class ApiClient {
         this.directoryAbortController?.abort();
         const controller = new AbortController();
         this.directoryAbortController = controller;
+        const cached = this.directoryCache.get(path);
+        const usesCachedView = Boolean(cached);
+        let ownsLoadingOverlay = false;
         try {
-            this.app.ui.showLoading();
-            const files = await this.getFiles(path, controller.signal);
+            if (cached) {
+                cached.usedAt = Date.now();
+                this.app.ui.displayFiles(cached.files);
+                this.app.ui.updateBreadcrumb(path);
+                this.app.ui.updateSidebarActiveState(path);
+                this.app.ui.setDirectoryStatus('refreshing', 'Refreshing directory…');
+            } else {
+                ownsLoadingOverlay = true;
+                this.app.ui.showLoading();
+                this.app.ui.setDirectoryStatus('loading', 'Loading directory…');
+            }
+            const response = await this.getFiles(path, { signal: controller.signal, detailed: true });
             if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
 
-            if (files !== null) {
-                this.app.ui.displayFiles(files);
+            if (response.files !== null) {
+                if (!response.notModified) this.app.ui.displayFiles(response.files);
                 this.app.ui.updateBreadcrumb(path);
                 this.app.ui.updateSidebarActiveState(path);
                 this.app.ui.updateToolbar();
+                this.app.ui.setDirectoryStatus('ready');
             } else {
-                this.notifyApiError(`Failed to load directory: ${path}`);
-                this.app.ui.displayFiles([]);
+                const message = response.error?.message || `Failed to load directory: ${path}`;
+                this.notifyApiError(message);
+                if (usesCachedView) this.app.ui.setDirectoryStatus('stale', 'Showing saved results · refresh failed');
+                else this.app.ui.displayDirectoryError(path, message);
             }
         } catch (error) {
             if (error.name === 'AbortError') return;
             if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
-            this.notifyApiError('An unexpected error occurred while loading files.', { error, context: 'in loadFiles' });
-            this.app.ui.displayFiles([]);
+            const message = 'An unexpected error occurred while loading files.';
+            this.notifyApiError(message, { error, context: 'in loadFiles' });
+            if (usesCachedView) this.app.ui.setDirectoryStatus('stale', 'Showing saved results · refresh failed');
+            else this.app.ui.displayDirectoryError(path, message);
         } finally {
             // Every request owns one loading reference, including requests that
             // become stale or are aborted by a newer navigation.
-            this.app.ui.hideLoading();
+            if (ownsLoadingOverlay) this.app.ui.hideLoading();
         }
     }
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -158,7 +158,7 @@ export class SearchHandler {
     async navigateToFolder(path) {
         try {
             const normalizedPath = this.fileManager.util.normalizePath(path);
-            const result = await this.fileManager.api.getFiles(normalizedPath, false); // Don't use cache
+            const result = await this.fileManager.api.getFiles(normalizedPath, { useCache: false });
             if (result) {
                 this.exitSearchMode(true);
                 const searchInput = document.querySelector('.search-input');

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -130,6 +130,46 @@ export class UIManager {
         container.appendChild(noFiles);
     }
 
+    setDirectoryStatus(status, message = '') {
+        const header = document.querySelector('.header');
+        if (!header) return;
+        let indicator = header.querySelector('.directory-status');
+        if (status === 'ready') {
+            indicator?.remove();
+            return;
+        }
+        if (!indicator) {
+            indicator = document.createElement('div');
+            indicator.className = 'directory-status';
+            indicator.setAttribute('role', 'status');
+            indicator.setAttribute('aria-live', 'polite');
+            header.appendChild(indicator);
+        }
+        indicator.dataset.status = status;
+        indicator.textContent = message;
+    }
+
+    displayDirectoryError(path, message) {
+        const container = document.querySelector('.file-browser');
+        if (!container) return;
+        container.replaceChildren();
+        const panel = document.createElement('section');
+        panel.className = 'directory-error';
+        panel.setAttribute('role', 'alert');
+        const title = document.createElement('h2');
+        title.textContent = 'Folder could not be loaded';
+        const description = document.createElement('p');
+        description.textContent = message;
+        const retry = document.createElement('button');
+        retry.type = 'button';
+        retry.className = 'btn btn-primary';
+        retry.textContent = 'Retry';
+        retry.addEventListener('click', () => this.app.loadFiles(path));
+        panel.append(title, description, retry);
+        container.appendChild(panel);
+        this.setDirectoryStatus('error', 'Directory refresh failed');
+    }
+
     createViewToggle(hasMasonrySupport = false, hasVideoSupport = false) {
         const viewToggle = document.createElement('div');
         viewToggle.className = 'view-toggle';


### PR DESCRIPTION
## Summary
- render cached directories immediately while revalidating in the background
- avoid rerendering unchanged 304 responses
- preserve stale results when refresh fails and show a compact status
- distinguish empty folders from initial load failures with an accessible Retry state
- reserve the full-screen loader for uncached directory loads

## Tests
- go test ./...
- go vet ./...
- node --check static/js/api.js
- node --check static/js/search.js
- node --check static/js/ui.js
- git diff --check