### PR TITLE
feat: paginate and virtualize directories

### DIFF
--- a/handlers/directory_pagination_test.go
+++ b/handlers/directory_pagination_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"puremania/types"
+)
+
+func TestListFilesReturnsStablePages(t *testing.T) {
+	storage := t.TempDir()
+	for _, name := range []string{"c.txt", "a.txt", "b.txt"} {
+		if err := os.WriteFile(filepath.Join(storage, name), []byte(name), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	h := NewHandler(&types.Config{StorageDir: storage}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	requestPage := func(cursor string) struct {
+		Success bool          `json:"success"`
+		Data    directoryPage `json:"data"`
+	} {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/files?path=/&limit=2&cursor="+cursor+"&sort=name&direction=asc", nil)
+		res := httptest.NewRecorder()
+		h.ListFiles(res, req)
+		if res.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+		}
+		var response struct {
+			Success bool          `json:"success"`
+			Data    directoryPage `json:"data"`
+		}
+		if err := json.Unmarshal(res.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		return response
+	}
+
+	first := requestPage("")
+	if !first.Data.HasMore || first.Data.NextCursor != "2" || len(first.Data.Data) != 2 || first.Data.Data[0].Name != "a.txt" {
+		t.Fatalf("unexpected first page: %#v", first.Data)
+	}
+	second := requestPage(first.Data.NextCursor)
+	if second.Data.HasMore || len(second.Data.Data) != 1 || second.Data.Data[0].Name != "c.txt" {
+		t.Fatalf("unexpected second page: %#v", second.Data)
+	}
+}

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -17,6 +17,7 @@ import (
 	"puremania/types"
 	"puremania/utils"
 	"puremania/worker"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -309,6 +310,10 @@ func (h *Handler) ListFiles(w http.ResponseWriter, r *http.Request) {
 		h.serveFreshFileList(w, path, "") // ETagなしで提供
 		return
 	}
+	if limit, parseErr := strconv.Atoi(r.URL.Query().Get("limit")); parseErr == nil && limit > 0 {
+		h.servePaginatedFileList(w, r, path, currentStateKey, limit)
+		return
+	}
 
 	// 2. クライアントのETagと比較
 	clientEtag := r.Header.Get("If-None-Match")
@@ -331,6 +336,109 @@ func (h *Handler) ListFiles(w http.ResponseWriter, r *http.Request) {
 
 	// 5. キャッシュがない場合は、新しいファイルリストを生成
 	h.serveFreshFileList(w, path, currentStateKey)
+}
+
+type directoryPage struct {
+	Data       []types.FileInfo `json:"data"`
+	NextCursor string           `json:"nextCursor,omitempty"`
+	HasMore    bool             `json:"hasMore"`
+	Offset     int              `json:"offset"`
+	Total      int              `json:"total"`
+}
+
+func (h *Handler) servePaginatedFileList(w http.ResponseWriter, r *http.Request, path, stateKey string, limit int) {
+	if limit > 500 {
+		limit = 500
+	}
+	offset, _ := strconv.Atoi(r.URL.Query().Get("cursor"))
+	if offset < 0 {
+		offset = 0
+	}
+	sortField := r.URL.Query().Get("sort")
+	if sortField == "" {
+		sortField = "name"
+	}
+	direction := r.URL.Query().Get("direction")
+	if direction != "desc" {
+		direction = "asc"
+	}
+	pageState := fmt.Sprintf("%s:%d:%d:%s:%s", stateKey, offset, limit, sortField, direction)
+	pageHash := sha256.Sum256([]byte(pageState))
+	etag := hex.EncodeToString(pageHash[:])
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("ETag", etag)
+
+	cacheKey := "list:" + stateKey
+	var files []types.FileInfo
+	if cached, found := cache.Get(h.cache, cacheKey); found {
+		files, _ = cached.([]types.FileInfo)
+	}
+	if files == nil {
+		var err error
+		files, err = h.getFileList(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				h.respondError(w, "Directory not found", http.StatusNotFound)
+			} else {
+				h.respondError(w, "Cannot read directory", http.StatusInternalServerError)
+			}
+			return
+		}
+		cache.Set(h.cache, cacheKey, files, int64(len(files)*200), CacheTTL)
+	}
+
+	pageFiles := append([]types.FileInfo(nil), files...)
+	sort.SliceStable(pageFiles, func(i, j int) bool {
+		left, right := pageFiles[i], pageFiles[j]
+		comparison := 0
+		switch sortField {
+		case "size":
+			comparison = compareInt64(left.Size, right.Size)
+		case "modified":
+			comparison = strings.Compare(left.ModTime, right.ModTime)
+		case "type":
+			comparison = strings.Compare(fileSortType(left), fileSortType(right))
+		default:
+			comparison = strings.Compare(strings.ToLower(left.Name), strings.ToLower(right.Name))
+		}
+		if comparison == 0 {
+			comparison = strings.Compare(left.Path, right.Path)
+		}
+		if direction == "desc" {
+			return comparison > 0
+		}
+		return comparison < 0
+	})
+	if offset > len(pageFiles) {
+		offset = len(pageFiles)
+	}
+	end := min(offset+limit, len(pageFiles))
+	hasMore := end < len(pageFiles)
+	nextCursor := ""
+	if hasMore {
+		nextCursor = strconv.Itoa(end)
+	}
+	h.respondSuccess(w, directoryPage{Data: pageFiles[offset:end], NextCursor: nextCursor, HasMore: hasMore, Offset: offset, Total: len(pageFiles)})
+}
+
+func compareInt64(left, right int64) int {
+	if left < right {
+		return -1
+	}
+	if left > right {
+		return 1
+	}
+	return 0
+}
+
+func fileSortType(file types.FileInfo) string {
+	if file.IsDir {
+		return "dir"
+	}
+	return file.MimeType
 }
 
 // serveFreshFileList は新しいファイルリストを生成し、必要に応じてキャッシュに保存する

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -13,15 +13,19 @@ export class ApiClient {
         this.directoryAbortController = null;
     }
 
-    cacheDirectory(path, etag, files) {
+    directoryCacheKey(path, { limit = 0, cursor = '', sort = '', direction = '' } = {}) {
+        return limit ? `${path}|${limit}|${cursor}|${sort}|${direction}` : path;
+    }
+
+    cacheDirectory(key, path, etag, files, page = null) {
         // Do not retain a single massive listing in addition to its rendered UI.
         if (files.length > MAX_CACHED_ENTRIES) {
-            this.directoryEtags.delete(path);
-            this.directoryCache.delete(path);
+            this.directoryEtags.delete(key);
+            this.directoryCache.delete(key);
             return;
         }
-        this.directoryEtags.set(path, etag);
-        this.directoryCache.set(path, { files, usedAt: Date.now() });
+        this.directoryEtags.set(key, etag);
+        this.directoryCache.set(key, { path, files, page, usedAt: Date.now() });
         while (this.directoryCache.size > MAX_CACHED_DIRECTORIES || this.cachedEntryCount() > MAX_CACHED_ENTRIES) {
             const oldest = [...this.directoryCache.entries()].reduce((candidate, entry) => entry[1].usedAt < candidate[1].usedAt ? entry : candidate)[0];
             this.directoryCache.delete(oldest);
@@ -91,8 +95,12 @@ export class ApiClient {
 
     invalidateDirectory(path) {
         if (!path) return;
-        this.directoryEtags.delete(path);
-        this.directoryCache.delete(path);
+        for (const [key, entry] of this.directoryCache) {
+            if (entry.path === path) {
+                this.directoryEtags.delete(key);
+                this.directoryCache.delete(key);
+            }
+        }
     }
 
     invalidateDirectories(paths) {
@@ -143,22 +151,25 @@ export class ApiClient {
         }
     }
 
-    async getFiles(path, { signal = null, useCache = true, detailed = false } = {}) {
+    async getFiles(path, { signal = null, useCache = true, detailed = false, limit = 0, cursor = '', sort = '', direction = '' } = {}) {
         try {
+            const key = this.directoryCacheKey(path, { limit, cursor, sort, direction });
             const headers = {};
-            const etag = this.directoryEtags.get(path);
-            if (useCache && etag && this.directoryCache.has(path)) {
+            const etag = this.directoryEtags.get(key);
+            if (useCache && etag && this.directoryCache.has(key)) {
                 headers['If-None-Match'] = etag;
             }
 
-            const response = await fetch(buildApiUrl('/api/files', { path }), { headers, signal });
+            const query = { path };
+            if (limit) Object.assign(query, { limit, cursor, sort, direction });
+            const response = await fetch(buildApiUrl('/api/files', query), { headers, signal });
 
             if (response.status === 304) {
                 console.log(`Content for ${path} not modified. Using cache.`);
-                const cached = this.directoryCache.get(path);
+                const cached = this.directoryCache.get(key);
                 if (cached) cached.usedAt = Date.now();
-                const response = { files: cached?.files || [], notModified: true, error: null };
-                return detailed ? response : response.files;
+                const result = { files: cached?.files || [], page: cached?.page || null, notModified: true, error: null };
+                return detailed ? result : result.files;
             }
 
             if (!response.ok) {
@@ -170,9 +181,10 @@ export class ApiClient {
             const result = await response.json();
             
             if (result.success) {
-                const files = result.data || [];
-                this.cacheDirectory(path, newEtag || '', files);
-                const response = { files, notModified: false, error: null };
+                const page = limit ? result.data : null;
+                const files = limit ? (page?.data || []) : (result.data || []);
+                this.cacheDirectory(key, path, newEtag || '', files, page);
+                const response = { files, page, notModified: false, error: null };
                 return detailed ? response : files;
             } else {
                 throw new Error(result.message || 'API returned success:false');
@@ -184,18 +196,20 @@ export class ApiClient {
         }
     }
 
-    async loadFiles(path) {
+    async loadFiles(path, { cursor = '', pageNumber = 0 } = {}) {
         const requestId = ++this.directoryRequestId;
         this.directoryAbortController?.abort();
         const controller = new AbortController();
         this.directoryAbortController = controller;
-        const cached = this.directoryCache.get(path);
+        const pagination = { limit: 200, cursor, sort: this.app.ui.sortState.field, direction: this.app.ui.sortState.direction };
+        const cacheKey = this.directoryCacheKey(path, pagination);
+        const cached = this.directoryCache.get(cacheKey);
         const usesCachedView = Boolean(cached);
         let ownsLoadingOverlay = false;
         try {
             if (cached) {
                 cached.usedAt = Date.now();
-                this.app.ui.displayFiles(cached.files);
+                this.app.ui.displayFiles(cached.files, { page: cached.page, pageNumber });
                 this.app.ui.updateBreadcrumb(path);
                 this.app.ui.updateSidebarActiveState(path);
                 this.app.ui.setDirectoryStatus('refreshing', 'Refreshing directory…');
@@ -204,11 +218,11 @@ export class ApiClient {
                 this.app.ui.showLoading();
                 this.app.ui.setDirectoryStatus('loading', 'Loading directory…');
             }
-            const response = await this.getFiles(path, { signal: controller.signal, detailed: true });
+            const response = await this.getFiles(path, { signal: controller.signal, detailed: true, ...pagination });
             if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
 
             if (response.files !== null) {
-                if (!response.notModified) this.app.ui.displayFiles(response.files);
+                if (!response.notModified) this.app.ui.displayFiles(response.files, { page: response.page, pageNumber });
                 this.app.ui.updateBreadcrumb(path);
                 this.app.ui.updateSidebarActiveState(path);
                 this.app.ui.updateToolbar();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -107,8 +107,8 @@ class FileManagerApp {
         });
     }
 
-    async loadFiles(path) {
-        await this.api.loadFiles(path);
+    async loadFiles(path, options = {}) {
+        await this.api.loadFiles(path, options);
         this.uploader.bindUploadEvents();
     }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -9,17 +9,25 @@ export class UIManager {
         this.previousPath = null;
         this.currentFiles = [];
         this.sortState = {
-            field: 'type',
-            direction: 'desc'
+            field: 'name',
+            direction: 'asc'
         };
         this.fileBrowserExtensionsVisible = false;
         this.lazyImageObserver = null;
         this.imageLoader = new ImageLoader();
         this.pendingOperations = 0;
+        this.directoryPage = null;
+        this.directoryPageNumber = 0;
+        this.removeVirtualScroll = null;
+        this.nameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
     }
 
-    displayFiles(files) {
+    displayFiles(files, { page = null, pageNumber = 0 } = {}) {
         this.currentFiles = files;
+        this.directoryPage = page;
+        this.directoryPageNumber = pageNumber;
+        this.removeVirtualScroll?.();
+        this.removeVirtualScroll = null;
         const container = document.querySelector('.file-browser');
         if (!container) return;
         this.resetLazyImageObserver();
@@ -27,14 +35,6 @@ export class UIManager {
         const currentPath = this.app.router.getCurrentPath();
         const isNewFolder = currentPath !== this.previousPath;
         this.previousPath = currentPath;
-
-        if (isNewFolder) {
-            const imageFileCount = files.filter(file => file.mime_type && file.mime_type.startsWith('image/')).length;
-            const musicFileCount = files.filter(file => file.mime_type && file.mime_type.startsWith('audio/')).length;
-            const shouldPreferNameSort = imageFileCount >= 10 || musicFileCount >= 10;
-            this.sortState.field = shouldPreferNameSort ? 'name' : 'type';
-            this.sortState.direction = shouldPreferNameSort ? 'asc' : 'desc';
-        }
 
         container.innerHTML = '';
         this.renderHeaderToggle();
@@ -48,21 +48,24 @@ export class UIManager {
             return;
         }
 
-        const sortedFiles = this.sortFiles(files);
+        const sortedFiles = page ? files : this.sortFiles(files);
         const imageCount = sortedFiles.filter(f => f.mime_type && f.mime_type.startsWith('image/')).length;
         const videoCount = sortedFiles.filter(f => f.mime_type && f.mime_type.startsWith('video/')).length;
         const hasMasonrySupport = imageCount >= 10;
         const hasVideoSupport = videoCount > 0;
+        const isLargeDirectory = (page?.total || files.length) > files.length;
 
-            if (isNewFolder && hasMasonrySupport) this.viewMode = 'masonry';
+            if (isNewFolder && hasMasonrySupport && !isLargeDirectory) this.viewMode = 'masonry';
             // if (isNewFolder && hasVideoSupport && !hasMasonrySupport) this.viewMode = 'video';
             if (this.viewMode === 'masonry' && !hasMasonrySupport) this.viewMode = 'grid';
             if (this.viewMode === 'video' && !hasVideoSupport) this.viewMode = 'grid';
+            if (isLargeDirectory && (this.viewMode === 'masonry' || this.viewMode === 'video')) this.viewMode = 'grid';
         if (this.viewMode === 'masonry') {
             this.renderMasonryView(sortedFiles, container, hasVideoSupport);
         } else {
             this.renderStandardView(sortedFiles, container, hasMasonrySupport, hasVideoSupport);
         }
+        this.renderDirectoryPagination(container);
         this.syncSelectionClasses(container);
     }
 
@@ -207,6 +210,7 @@ export class UIManager {
         container.appendChild(viewToggle);
 
         const fileContainer = document.createElement('div');
+        container.appendChild(fileContainer);
         if (this.viewMode === 'list') {
             fileContainer.className = 'table-view-container';
             this.renderListView(files, fileContainer);
@@ -217,7 +221,6 @@ export class UIManager {
             fileContainer.className = 'file-grid';
             this.renderGridView(files, fileContainer);
         }
-        container.appendChild(fileContainer);
     }
 
     renderVideoView(files, container) {
@@ -321,6 +324,10 @@ export class UIManager {
     }
 
     renderGridView(files, container) {
+        if (files.length > 80) {
+            this.renderVirtualGrid(files, container);
+            return;
+        }
         files.forEach(file => {
             const fileItem = this.createFileItem(file);
             container.appendChild(fileItem);
@@ -350,6 +357,10 @@ export class UIManager {
     }
 
     renderListView(files, container) {
+        if (files.length > 80) {
+            this.renderVirtualList(files, container);
+            return;
+        }
         const table = this.createListViewTable(
             files,
             this.sortState.field,
@@ -395,8 +406,98 @@ export class UIManager {
             this.sortState.field = field;
             this.sortState.direction = 'asc';
         }
-        this.displayFiles(this.currentFiles);
-        this.app.uploader.bindUploadEvents();
+        this.app.loadFiles(this.app.router.getCurrentPath());
+    }
+
+    bindVirtualScroll(render) {
+        const browser = document.querySelector('.file-browser');
+        if (!browser) return;
+        let frame = 0;
+        const onScroll = () => {
+            if (frame) return;
+            frame = requestAnimationFrame(() => { frame = 0; render(); });
+        };
+        browser.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        this.removeVirtualScroll = () => {
+            browser.removeEventListener('scroll', onScroll);
+            window.removeEventListener('resize', onScroll);
+            if (frame) cancelAnimationFrame(frame);
+        };
+        render();
+    }
+
+    renderVirtualGrid(files, container) {
+        const rowHeight = 190;
+        this.bindVirtualScroll(() => {
+            const browser = document.querySelector('.file-browser');
+            const columns = Math.max(1, Math.floor(container.clientWidth / 160));
+            const firstRow = Math.max(0, Math.floor((browser.scrollTop - container.offsetTop) / rowHeight) - 3);
+            const visibleRows = Math.ceil(browser.clientHeight / rowHeight) + 6;
+            const lastRow = Math.min(Math.ceil(files.length / columns), firstRow + visibleRows);
+            const start = firstRow * columns;
+            const end = Math.min(files.length, lastRow * columns);
+            const top = document.createElement('div');
+            top.className = 'virtual-spacer';
+            top.style.cssText = `grid-column:1/-1;height:${firstRow * rowHeight}px`;
+            const bottom = document.createElement('div');
+            bottom.className = 'virtual-spacer';
+            bottom.style.cssText = `grid-column:1/-1;height:${Math.max(0, (Math.ceil(files.length / columns) - lastRow) * rowHeight)}px`;
+            container.replaceChildren(top, ...files.slice(start, end).map(file => this.createFileItem(file)), bottom);
+            this.syncSelectionClasses(container);
+        });
+    }
+
+    renderVirtualList(files, container) {
+        const table = this.createListViewTable([], this.sortState.field, this.sortState.direction, field => this.setSort(field));
+        const body = table.querySelector('tbody');
+        container.appendChild(table);
+        const rowHeight = 48;
+        this.bindVirtualScroll(() => {
+            const browser = document.querySelector('.file-browser');
+            const start = Math.max(0, Math.floor((browser.scrollTop - table.offsetTop) / rowHeight) - 10);
+            const count = Math.ceil(browser.clientHeight / rowHeight) + 20;
+            const end = Math.min(files.length, start + count);
+            const spacer = height => {
+                const row = document.createElement('tr');
+                row.className = 'virtual-spacer';
+                const cell = document.createElement('td');
+                cell.colSpan = 5;
+                cell.style.height = `${height}px`;
+                row.appendChild(cell);
+                return row;
+            };
+            body.replaceChildren(spacer(start * rowHeight), ...files.slice(start, end).map(file => this.createTableRow(file)), spacer((files.length - end) * rowHeight));
+            this.syncSelectionClasses(body);
+        });
+    }
+
+    renderDirectoryPagination(container) {
+        const page = this.directoryPage;
+        if (!page || (page.offset === 0 && !page.hasMore)) return;
+        const controls = document.createElement('nav');
+        controls.className = 'pagination-controls directory-pagination';
+        controls.setAttribute('aria-label', 'Directory pages');
+        const previous = document.createElement('button');
+        previous.type = 'button';
+        previous.className = 'pagination-btn';
+        previous.textContent = '← Previous';
+        previous.disabled = page.offset === 0;
+        previous.addEventListener('click', () => this.app.loadFiles(this.app.router.getCurrentPath(), {
+            cursor: String(Math.max(0, page.offset - 200)), pageNumber: Math.max(0, this.directoryPageNumber - 1)
+        }));
+        const label = document.createElement('span');
+        label.textContent = `Page ${this.directoryPageNumber + 1} · ${page.offset + 1}-${page.offset + page.data.length} of ${page.total}`;
+        const next = document.createElement('button');
+        next.type = 'button';
+        next.className = 'pagination-btn';
+        next.textContent = 'Next →';
+        next.disabled = !page.hasMore;
+        next.addEventListener('click', () => this.app.loadFiles(this.app.router.getCurrentPath(), {
+            cursor: page.nextCursor, pageNumber: this.directoryPageNumber + 1
+        }));
+        controls.append(previous, label, next);
+        container.appendChild(controls);
     }
 
     sortFiles(files) {
@@ -404,8 +505,13 @@ export class UIManager {
             const field = this.sortState.field;
             const dir = this.sortState.direction === 'asc' ? 1 : -1;
             
-            let valA = field === 'name' ? a.name.toLowerCase() : (a[field] || 0);
-            let valB = field === 'name' ? b.name.toLowerCase() : (b[field] || 0);
+            if (field === 'name') {
+                const comparison = this.nameCollator.compare(a.name, b.name);
+                return comparison * dir;
+            }
+
+            let valA = a[field] || 0;
+            let valB = b[field] || 0;
 
             if (field === 'type') {
                 valA = a.is_dir ? 'dir' : (a.mime_type || 'file');


### PR DESCRIPTION
## Summary
- add server-side directory sorting and 200-entry cursor pages
- cache and revalidate directory pages independently
- add Previous/Next navigation without retaining complete directories in the browser
- virtualize grid and list pages so only the visible window is in the DOM
- use Intl.Collator for remaining client-side name sorting
- test stable server pagination and cursors

## Tests
- go test ./...
- go vet ./...
- node --check static/js/api.js
- node --check static/js/app.js
- node --check static/js/ui.js
- git diff --check