### PR TITLE
refactor: centralize frontend application state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+      - name: Run frontend tests
+        run: npm test
+
       - name: Run go vet
         run: go vet ./...
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Frontend dependencies for Pure Mania",
   "scripts": {
-    "build": "node build.js"
+    "build": "node build.js",
+    "test": "node --test static/js/*.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.17.0",

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -9,7 +9,6 @@ export class ApiClient {
         this.app = app;
         this.directoryEtags = new Map();
         this.directoryCache = new Map();
-        this.directoryRequestId = 0;
         this.directoryAbortController = null;
     }
 
@@ -197,7 +196,8 @@ export class ApiClient {
     }
 
     async loadFiles(path, { cursor = '', pageNumber = 0 } = {}) {
-        const requestId = ++this.directoryRequestId;
+        const requestId = this.app.store.getState().directory.requestId + 1;
+        this.app.store.update('directory', { path, requestId, status: 'loading' }, 'DIRECTORY_LOAD_STARTED');
         this.directoryAbortController?.abort();
         const controller = new AbortController();
         this.directoryAbortController = controller;
@@ -208,6 +208,7 @@ export class ApiClient {
         let ownsLoadingOverlay = false;
         try {
             if (cached) {
+                this.app.store.update('directory', { status: 'refreshing' }, 'DIRECTORY_CACHE_SHOWN');
                 cached.usedAt = Date.now();
                 this.app.ui.displayFiles(cached.files, { page: cached.page, pageNumber });
                 this.app.ui.updateBreadcrumb(path);
@@ -219,7 +220,7 @@ export class ApiClient {
                 this.app.ui.setDirectoryStatus('loading', 'Loading directory…');
             }
             const response = await this.getFiles(path, { signal: controller.signal, detailed: true, ...pagination });
-            if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
+            if (requestId !== this.app.store.getState().directory.requestId || this.app.store.getState().route.path !== path) return;
 
             if (response.files !== null) {
                 if (!response.notModified) this.app.ui.displayFiles(response.files, { page: response.page, pageNumber });
@@ -227,19 +228,30 @@ export class ApiClient {
                 this.app.ui.updateSidebarActiveState(path);
                 this.app.ui.updateToolbar();
                 this.app.ui.setDirectoryStatus('ready');
+                this.app.store.update('directory', { status: response.files.length ? 'ready' : 'empty' }, 'DIRECTORY_LOADED');
             } else {
                 const message = response.error?.message || `Failed to load directory: ${path}`;
                 this.notifyApiError(message);
-                if (usesCachedView) this.app.ui.setDirectoryStatus('stale', 'Showing saved results · refresh failed');
-                else this.app.ui.displayDirectoryError(path, message);
+                if (usesCachedView) {
+                    this.app.store.update('directory', { status: 'stale' }, 'DIRECTORY_REFRESH_FAILED');
+                    this.app.ui.setDirectoryStatus('stale', 'Showing saved results · refresh failed');
+                } else {
+                    this.app.store.update('directory', { status: 'error' }, 'DIRECTORY_LOAD_FAILED');
+                    this.app.ui.displayDirectoryError(path, message);
+                }
             }
         } catch (error) {
             if (error.name === 'AbortError') return;
-            if (requestId !== this.directoryRequestId || this.app.router.getCurrentPath() !== path) return;
+            if (requestId !== this.app.store.getState().directory.requestId || this.app.store.getState().route.path !== path) return;
             const message = 'An unexpected error occurred while loading files.';
             this.notifyApiError(message, { error, context: 'in loadFiles' });
-            if (usesCachedView) this.app.ui.setDirectoryStatus('stale', 'Showing saved results · refresh failed');
-            else this.app.ui.displayDirectoryError(path, message);
+            if (usesCachedView) {
+                this.app.store.update('directory', { status: 'stale' }, 'DIRECTORY_REFRESH_FAILED');
+                this.app.ui.setDirectoryStatus('stale', 'Showing saved results · refresh failed');
+            } else {
+                this.app.store.update('directory', { status: 'error' }, 'DIRECTORY_LOAD_FAILED');
+                this.app.ui.displayDirectoryError(path, message);
+            }
         } finally {
             // Every request owns one loading reference, including requests that
             // become stale or are aborted by a newer navigation.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -12,20 +12,18 @@ import { Util } from './util.js';
 import { Aria2cPageHandler } from './aria2c-page.js';
 import { UploadPageHandler } from './upload-page.js';
 import { loadTemplates } from './template.js';
+import { AppStateStore } from './state.js';
 
 class FileManagerApp {
     constructor() {
-        this.selectedFiles = new Set();
-        this.selectionAnchorPath = null;
+        this.store = new AppStateStore();
         this.config = {};
         this.directoryScrollPositions = new Map();
-        this.renderedDirectoryPath = null;
-        this.editRequestId = 0;
         this.isPC = !/Mobi|Android/i.test(navigator.userAgent);
         this.eventBus = new EventTarget();
 
         // Initialize modules that don't depend on templates in their constructor
-        this.router = new Router();
+        this.router = new Router(this.store);
         this.util = new Util(this);
         this.api = new ApiClient(this);
         this.uploader = new Uploader(this);
@@ -47,6 +45,9 @@ class FileManagerApp {
         this.eventBus.dispatchEvent(event);
         return event;
     }
+
+    get selectedFiles() { return this.store.getState().selection.paths; }
+    get selectionAnchorPath() { return this.store.getState().selection.anchorPath; }
 
     async init() {
         // Initialize modules that need templates
@@ -84,7 +85,7 @@ class FileManagerApp {
         // Setup router
         this.router.onChange((path, { navigationType = 'initial' } = {}) => {
             if (path === '/system/uploads') {
-                if (this.aria2cPageHandler.isInAria2cMode) this.aria2cPageHandler.exitAria2cMode(false);
+                this.aria2cPageHandler.exitAria2cMode(false);
                 this.uploadPageHandler.enter();
             } else if (path === '/system/aria2c') {
                 this.uploadPageHandler.exit();
@@ -99,9 +100,7 @@ class FileManagerApp {
                 this.aria2cPageHandler.enterAria2cMode();
             } else {
                 this.uploadPageHandler.exit();
-                if (this.aria2cPageHandler.isInAria2cMode) {
-                    this.aria2cPageHandler.exitAria2cMode(false);
-                }
+                this.aria2cPageHandler.exitAria2cMode(false);
                 this.navigateToPath(path, { restoreScroll: navigationType === 'pop' });
             }
         });
@@ -114,8 +113,9 @@ class FileManagerApp {
 
     async navigateToPath(path, { restoreScroll = false } = {}) {
         const browser = document.querySelector('.file-browser');
-        if (browser && this.renderedDirectoryPath && this.renderedDirectoryPath !== path) {
-            this.directoryScrollPositions.set(this.renderedDirectoryPath, browser.scrollTop);
+        const renderedPath = this.store.getState().directory.renderedPath;
+        if (browser && renderedPath && renderedPath !== path) {
+            this.directoryScrollPositions.set(renderedPath, browser.scrollTop);
         }
         await this.loadFiles(path);
         const restorePosition = restoreScroll ? (this.directoryScrollPositions.get(path) ?? 0) : 0;
@@ -127,7 +127,6 @@ class FileManagerApp {
                 if (currentBrowser && this.router.getCurrentPath() === path) currentBrowser.scrollTop = restorePosition;
             });
         });
-        this.renderedDirectoryPath = path;
         this.clearSelection();
     }
 
@@ -139,10 +138,13 @@ class FileManagerApp {
     }
 
     async editFile(path) {
-        const requestId = ++this.editRequestId;
+        const requestId = this.store.getState().editor.loadRequestId + 1;
+        this.store.update('editor', { loadRequestId: requestId, status: 'loading', path }, 'EDITOR_LOAD_STARTED');
         const content = await this.api.fetchFileContent(path);
-        if (requestId === this.editRequestId && content !== null) {
+        if (requestId === this.store.getState().editor.loadRequestId && content !== null) {
             this.editor.open(path, content);
+        } else if (requestId === this.store.getState().editor.loadRequestId) {
+            this.store.update('editor', { status: 'closed', path: null }, 'EDITOR_LOAD_FAILED');
         }
     }
 
@@ -168,8 +170,7 @@ class FileManagerApp {
     }
 
     setSelection(paths, anchorPath = this.selectionAnchorPath) {
-        this.selectedFiles = new Set(paths);
-        this.selectionAnchorPath = anchorPath;
+        this.store.update('selection', { paths: new Set(paths), anchorPath }, 'SELECTION_CHANGED');
         this.ui.syncSelectionClasses();
         this.ui.updateToolbar();
     }

--- a/static/js/aria2c-page.js
+++ b/static/js/aria2c-page.js
@@ -3,7 +3,7 @@ import { getTemplateContent } from './template.js';
 export class Aria2cPageHandler {
     constructor(fileManager) {
         this.fileManager = fileManager;
-        this.isInAria2cMode = false;
+        this.pollEnabled = false;
         this.updateInterval = null;
         this.lastStatus = null;
         this.previousPath = '/'; // Store the path before entering this page
@@ -12,19 +12,23 @@ export class Aria2cPageHandler {
         this.pollTimer = null;
     }
 
+    get isInAria2cMode() {
+        return this.fileManager.store.getState().route.page === 'aria2c';
+    }
+
     init() {
         // No initial event binding needed, will be triggered by router
     }
 
     enterAria2cMode() {
-        if (this.isInAria2cMode) return;
+        if (this.pollEnabled) return;
 
         const currentPath = this.fileManager.router.getCurrentPath();
         if (currentPath !== '/system/aria2c') {
             this.previousPath = currentPath;
         }
 
-        this.isInAria2cMode = true;
+        this.pollEnabled = true;
         this.fileManager.ui.showLoading();
         this.loadAria2cStatus();
         
@@ -33,8 +37,8 @@ export class Aria2cPageHandler {
     }
 
     exitAria2cMode(navigate = true) {
-        if (!this.isInAria2cMode) return;
-        this.isInAria2cMode = false;
+        if (!this.pollEnabled) return;
+        this.pollEnabled = false;
         clearTimeout(this.pollTimer);
         this.updateInterval = null;
         this.lastStatus = null;
@@ -46,7 +50,7 @@ export class Aria2cPageHandler {
     }
 
     async loadAria2cStatus() {
-        if (!this.isInAria2cMode || this.polling) return;
+        if (!this.pollEnabled || !this.isInAria2cMode || this.polling) return;
         this.polling = true;
         try {
             const status = await this.fileManager.api.getAria2cStatus();
@@ -56,12 +60,12 @@ export class Aria2cPageHandler {
             } else {
                 // API method failed and should have shown a toast.
                 // Stop polling.
-                this.isInAria2cMode = false;
+                this.pollEnabled = false;
             }
         } finally {
             this.polling = false;
             this.fileManager.ui.hideLoading();
-            if (this.isInAria2cMode) this.pollTimer = setTimeout(() => this.loadAria2cStatus(), 2000);
+            if (this.pollEnabled && this.isInAria2cMode) this.pollTimer = setTimeout(() => this.loadAria2cStatus(), 2000);
         }
     }
 

--- a/static/js/file-editor.js
+++ b/static/js/file-editor.js
@@ -75,9 +75,7 @@ const getLanguageExtension = (filePath) => {
 export class FileEditor {
     constructor(app) {
         this.app = app;
-        this.currentFile = null;
         this.editorView = null;
-        this.saving = false;
         this.isPC = !/Mobi|Android/i.test(navigator.userAgent);
         this.vimCompartment = new Compartment();
 
@@ -89,6 +87,11 @@ export class FileEditor {
             this.defineVimCommands();
         }
     }
+
+    get currentFile() { return this.app.store.getState().editor.path; }
+    set currentFile(path) { this.app.store.update('editor', { path }, 'EDITOR_PATH_CHANGED'); }
+    get saving() { return this.app.store.getState().editor.status === 'saving'; }
+    set saving(saving) { this.app.store.update('editor', { status: saving ? 'saving' : this.currentFile ? 'editing' : 'closed' }, 'EDITOR_STATUS_CHANGED'); }
 
     defineVimCommands() {
         Vim.defineEx("w", "w", () => { this.save(); });
@@ -181,6 +184,10 @@ export class FileEditor {
             if (update.docChanged || update.selectionSet) {
                 this.updateStatusBar();
             }
+            if (update.docChanged) {
+                const currentContent = update.state.doc.toString();
+                this.app.store.update('editor', { currentContent, dirty: currentContent !== this.savedContent }, 'EDITOR_CONTENT_CHANGED');
+            }
         });
 
         return [
@@ -210,6 +217,7 @@ export class FileEditor {
     open(filePath, content) {
         this.currentFile = filePath;
         this.savedContent = content;
+        this.app.store.update('editor', { status: 'editing', originalContent: content, currentContent: content, dirty: false, error: null }, 'EDITOR_OPENED');
         this.filenameElement.textContent = filePath.split('/').pop();
 
         if (this.editorView) {
@@ -268,6 +276,7 @@ export class FileEditor {
         if (this.editorView && this.editorView.state.doc.toString() !== this.savedContent && !window.confirm('Discard unsaved changes?')) return;
         hideModalOverlay(this.editorElement);
         this.currentFile = null;
+        this.app.store.update('editor', { status: 'closed', originalContent: '', currentContent: '', dirty: false }, 'EDITOR_CLOSED');
         if (this.editorView) {
             this.editorView.destroy();
             this.editorView = null;
@@ -280,6 +289,8 @@ export class FileEditor {
 
         const content = this.editorView.state.doc.toString();
         const filePath = this.currentFile;
+        const saveRevision = this.app.store.getState().editor.saveRevision + 1;
+        this.app.store.update('editor', { saveRevision }, 'EDITOR_SAVE_STARTED');
         this.saving = true;
 
         try {
@@ -294,12 +305,14 @@ export class FileEditor {
             if (result.success) {
                 this.showToast('File saved successfully', 'success');
                 this.savedContent = content;
+                this.app.store.update('editor', { originalContent: content, currentContent: this.editorView?.state.doc.toString() || content, dirty: this.editorView?.state.doc.toString() !== content, error: null }, 'EDITOR_SAVED');
                 // Do not discard edits made while the request was in flight.
                 if (this.currentFile === filePath && this.editorView?.state.doc.toString() === content) this.close();
             } else {
                 this.showToast(result.message, 'error');
             }
         } catch (error) {
+            this.app.store.update('editor', { error: error.message }, 'EDITOR_SAVE_FAILED');
             this.showToast('Failed to save file', 'error');
             console.error('Error saving file:', error);
         } finally {

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -1,16 +1,21 @@
 import { normalizePath } from './util.js';
 
 export class Router {
-    constructor() {
+    constructor(store) {
+        this.store = store;
         this.routes = {};
-        this.currentPath = '';
         this.navigationType = 'initial';
-        this.route = { page: 'files', path: '/' };
         this.isInitialized = false;
         this.onRouteChange = null;
         
         this._setupEventListeners();
         this._initializeWhenReady();
+    }
+
+    get currentPath() { return this.store.getState().route.path; }
+    set currentPath(path) {
+        const page = path === '/system/uploads' ? 'uploads' : path === '/system/aria2c' ? 'aria2c' : 'files';
+        this.store.update('route', { page, path }, 'NAVIGATE');
     }
 
     /**
@@ -57,10 +62,6 @@ export class Router {
         console.log('Initial route:', currentPath);
         
         this.currentPath = currentPath;
-        this.route = {
-            page: currentPath === '/system/uploads' ? 'uploads' : currentPath === '/system/aria2c' ? 'aria2c' : 'files',
-            path: currentPath
-        };
         
         if (this.onRouteChange) {
             // FileManagerAppの初期化を待つための遅延
@@ -175,10 +176,6 @@ export class Router {
         }
         
         this.currentPath = path;
-        this.route = {
-            page: path === '/system/uploads' ? 'uploads' : path === '/system/aria2c' ? 'aria2c' : 'files',
-            path
-        };
         const navigationType = this.navigationType;
         this.navigationType = 'unknown';
         

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -10,8 +10,6 @@ export class SearchHandler {
         this.lastSearchResults = null;
         this.currentPage = 0;
         this.pageSize = 100;
-        this.totalResults = 0;
-        this.searchRequestId = 0;
         this.searchController = null;
         this.cursorHistory = [''];
         this.nextCursor = '';
@@ -27,6 +25,31 @@ export class SearchHandler {
         this.selectedCompletionIndex = -1;
         this.isShowingCompletions = false;
     }
+
+    get isInSearchMode() { return this.fileManager.store.getState().search.active; }
+    set isInSearchMode(active) { this.fileManager.store.update('search', { active }, 'SEARCH_MODE_CHANGED'); }
+    get isCdMode() { return this.fileManager.store.getState().search.commandMode === 'cd'; }
+    set isCdMode(active) {
+        const current = this.fileManager.store.getState().search.commandMode;
+        this.fileManager.store.update('search', { commandMode: active ? 'cd' : current === 'cd' ? null : current }, 'SEARCH_COMMAND_MODE_CHANGED');
+    }
+    get isAria2cMode() { return this.fileManager.store.getState().search.commandMode === 'aria2c'; }
+    set isAria2cMode(active) {
+        const current = this.fileManager.store.getState().search.commandMode;
+        this.fileManager.store.update('search', { commandMode: active ? 'aria2c' : current === 'aria2c' ? null : current }, 'SEARCH_COMMAND_MODE_CHANGED');
+    }
+    get lastSearchTerm() { return this.fileManager.store.getState().search.query; }
+    set lastSearchTerm(query) { this.fileManager.store.update('search', { query }, 'SEARCH_QUERY_CHANGED'); }
+    get lastSearchResults() { return this.fileManager.store.getState().search.results; }
+    set lastSearchResults(results) { this.fileManager.store.update('search', { results }, 'SEARCH_RESULTS_CHANGED'); }
+    get currentPage() { return this.fileManager.store.getState().search.page; }
+    set currentPage(page) { this.fileManager.store.update('search', { page }, 'SEARCH_PAGE_CHANGED'); }
+    get cursorHistory() { return this.fileManager.store.getState().search.cursorHistory; }
+    set cursorHistory(cursorHistory) { this.fileManager.store.update('search', { cursorHistory }, 'SEARCH_CURSORS_CHANGED'); }
+    get nextCursor() { return this.fileManager.store.getState().search.nextCursor; }
+    set nextCursor(nextCursor) { this.fileManager.store.update('search', { nextCursor }, 'SEARCH_CURSOR_CHANGED'); }
+    get hasMore() { return this.fileManager.store.getState().search.hasMore; }
+    set hasMore(hasMore) { this.fileManager.store.update('search', { hasMore }, 'SEARCH_CURSOR_CHANGED'); }
 
     init() {
         this.bindEvents();
@@ -367,31 +390,35 @@ export class SearchHandler {
         this.currentPage = page;
         if (page === 0) this.cursorHistory = [''];
         const cursor = this.cursorHistory[page] ?? '';
-        const requestId = ++this.searchRequestId;
+        const requestId = this.fileManager.store.getState().search.requestId + 1;
+        this.fileManager.store.update('search', { requestId, query: searchTerm, status: 'loading' }, 'SEARCH_STARTED');
         this.searchController?.abort();
         const controller = new AbortController();
         this.searchController = controller;
         this.fileManager.ui.showLoading();
         try {
             const result = await this.fileManager.api.search(searchTerm, this.fileManager.router.getCurrentPath(), this.searchOptions, this.pageSize, cursor, controller.signal);
-            if (requestId !== this.searchRequestId || controller.signal.aborted) return;
+            if (requestId !== this.fileManager.store.getState().search.requestId || controller.signal.aborted) return;
             if (result && result.success) {
                 const searchPage = result.data || {};
                 this.lastSearchResults = this.sortResults(searchPage.data || [], this.sortField, this.sortDirection);
                 this.nextCursor = searchPage.nextCursor || '';
                 this.hasMore = Boolean(searchPage.hasMore);
-                if (this.hasMore) this.cursorHistory[page + 1] = this.nextCursor;
-                this.cursorHistory.length = this.hasMore ? page + 2 : page + 1;
+                const cursorHistory = this.cursorHistory.slice(0, page + 1);
+                if (this.hasMore) cursorHistory[page + 1] = this.nextCursor;
+                this.cursorHistory = cursorHistory;
                 if (this.fileManager.ui.viewMode === 'masonry') {
                     this.fileManager.ui.viewMode = 'grid';
                 }
                 this.displaySearchResults(this.lastSearchResults, searchTerm, page);
+                this.fileManager.store.update('search', { status: this.lastSearchResults.length ? 'ready' : 'empty' }, 'SEARCH_COMPLETED');
             } else {
                 this.fileManager.ui.showToast('Search Error', result ? result.message : 'Unknown error', 'error');
             }
         } catch (error) {
             if (error.name === 'AbortError') return;
-            if (requestId !== this.searchRequestId) return;
+            if (requestId !== this.fileManager.store.getState().search.requestId) return;
+            this.fileManager.store.update('search', { status: 'error' }, 'SEARCH_FAILED');
             this.fileManager.ui.showToast('Search Error', 'Failed to perform search', 'error');
         } finally {
             this.fileManager.ui.hideLoading();
@@ -469,6 +496,7 @@ export class SearchHandler {
         this.lastSearchResults = null;
         this.lastSearchTerm = '';
         this.currentPage = 0;
+        this.fileManager.store.update('search', { active: false, query: '', status: 'idle', commandMode: null }, 'SEARCH_EXITED');
         this.searchController?.abort();
         this.searchController = null;
         this.cursorHistory = [''];

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -1,0 +1,30 @@
+export class AppStateStore {
+    constructor() {
+        this.state = {
+            route: { page: 'files', path: '/' },
+            directory: { path: '/', renderedPath: null, status: 'idle', requestId: 0, files: [], page: null },
+            selection: { paths: new Set(), anchorPath: null },
+            search: { active: false, query: '', status: 'idle', requestId: 0, commandMode: null, results: null, page: 0, cursorHistory: [''], nextCursor: '', hasMore: false },
+            editor: { path: null, status: 'closed', originalContent: '', currentContent: '', dirty: false, loadRequestId: 0, saveRevision: 0, error: null },
+            uploads: { activeBatchId: null, batches: new Map(), status: 'idle' },
+            ui: { pendingOperations: 0 }
+        };
+        this.listeners = new Set();
+    }
+
+    getState() {
+        return this.state;
+    }
+
+    update(slice, patch, action = slice) {
+        const previous = this.state;
+        this.state = { ...previous, [slice]: { ...previous[slice], ...patch } };
+        this.listeners.forEach(listener => listener(this.state, previous, action));
+        return this.state[slice];
+    }
+
+    subscribe(listener) {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+}

--- a/static/js/state.test.mjs
+++ b/static/js/state.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { AppStateStore } from './state.js';
+
+test('updates one state slice without replacing the others', () => {
+    const store = new AppStateStore();
+    const selection = store.getState().selection;
+    store.update('route', { page: 'uploads', path: '/system/uploads' }, 'NAVIGATE');
+    assert.deepEqual(store.getState().route, { page: 'uploads', path: '/system/uploads' });
+    assert.equal(store.getState().selection, selection);
+});
+
+test('notifies subscribers with action and previous state', () => {
+    const store = new AppStateStore();
+    let notification;
+    const unsubscribe = store.subscribe((state, previous, action) => { notification = { state, previous, action }; });
+    store.update('editor', { status: 'editing', path: '/notes.txt' }, 'EDITOR_OPENED');
+    assert.equal(notification.action, 'EDITOR_OPENED');
+    assert.equal(notification.previous.editor.status, 'closed');
+    assert.equal(notification.state.editor.path, '/notes.txt');
+    unsubscribe();
+});

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -6,8 +6,6 @@ export class UIManager {
     constructor(app) {
         this.app = app;
         this.viewMode = 'grid';
-        this.previousPath = null;
-        this.currentFiles = [];
         this.sortState = {
             field: 'name',
             direction: 'asc'
@@ -15,15 +13,15 @@ export class UIManager {
         this.fileBrowserExtensionsVisible = false;
         this.lazyImageObserver = null;
         this.imageLoader = new ImageLoader();
-        this.pendingOperations = 0;
         this.directoryPage = null;
         this.directoryPageNumber = 0;
         this.removeVirtualScroll = null;
         this.nameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
     }
 
+    get currentFiles() { return this.app.store.getState().directory.files; }
+
     displayFiles(files, { page = null, pageNumber = 0 } = {}) {
-        this.currentFiles = files;
         this.directoryPage = page;
         this.directoryPageNumber = pageNumber;
         this.removeVirtualScroll?.();
@@ -33,8 +31,8 @@ export class UIManager {
         this.resetLazyImageObserver();
 
         const currentPath = this.app.router.getCurrentPath();
-        const isNewFolder = currentPath !== this.previousPath;
-        this.previousPath = currentPath;
+        const isNewFolder = currentPath !== this.app.store.getState().directory.renderedPath;
+        this.app.store.update('directory', { renderedPath: currentPath, files, page }, 'DIRECTORY_RENDERED');
 
         container.innerHTML = '';
         this.renderHeaderToggle();
@@ -741,14 +739,16 @@ export class UIManager {
     }
 
     showLoading() {
-        this.pendingOperations++;
+        const pendingOperations = this.app.store.getState().ui.pendingOperations + 1;
+        this.app.store.update('ui', { pendingOperations }, 'OPERATION_STARTED');
         const overlay = document.getElementById('loading-overlay');
         if (overlay) overlay.style.display = 'flex';
     }
 
     hideLoading() {
-        this.pendingOperations = Math.max(0, this.pendingOperations - 1);
-        if (this.pendingOperations === 0) {
+        const pendingOperations = Math.max(0, this.app.store.getState().ui.pendingOperations - 1);
+        this.app.store.update('ui', { pendingOperations }, 'OPERATION_FINISHED');
+        if (pendingOperations === 0) {
             const overlay = document.getElementById('loading-overlay');
             if (overlay) overlay.style.display = 'none';
         }

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -3,7 +3,7 @@
 export class UploadPageHandler {
     constructor(app) {
         this.app = app;
-        this.active = false;
+        this.pollEnabled = false;
         this.selectedKeys = new Set();
         this.polling = false;
         this.timer = null;
@@ -11,17 +11,21 @@ export class UploadPageHandler {
         this.onJobsChanged = () => this.refresh();
     }
 
+    get isActive() {
+        return this.app.store.getState().route.page === 'uploads';
+    }
+
     enter() {
-        if (this.active) return;
-        this.active = true;
+        if (this.pollEnabled) return;
+        this.pollEnabled = true;
         window.addEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
         this.refresh();
         document.querySelector('.breadcrumbs')?.style.setProperty('display', 'none');
     }
 
     exit() {
-        if (!this.active) return;
-        this.active = false;
+        if (!this.pollEnabled) return;
+        this.pollEnabled = false;
         clearTimeout(this.timer);
         this.refreshController?.abort();
         this.refreshController = null;
@@ -30,19 +34,19 @@ export class UploadPageHandler {
     }
 
     async refresh() {
-        if (!this.active || this.polling) return;
+        if (!this.pollEnabled || !this.isActive || this.polling) return;
         this.polling = true;
         const controller = new AbortController();
         this.refreshController = controller;
         try {
             const jobs = await this.app.uploader.listJobs(controller.signal);
-            if (this.active && !controller.signal.aborted) this.render(jobs);
+            if (this.pollEnabled && this.isActive && !controller.signal.aborted) this.render(jobs);
         } catch (error) {
             if (error.name !== 'AbortError') console.error('Failed to refresh uploads', error);
         } finally {
             if (this.refreshController === controller) this.refreshController = null;
             this.polling = false;
-            if (this.active) this.timer = setTimeout(() => this.refresh(), 3000);
+            if (this.pollEnabled && this.isActive) this.timer = setTimeout(() => this.refresh(), 3000);
         }
     }
 

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -106,12 +106,32 @@ export class Uploader {
     constructor(app) {
         this.app = app;
         this._processingDrop = false;
-        this.activeUploadSession = null;
         this.store = new UploadSessionStore();
-        this.progress = new Map();
-        this.uploadStats = null;
         this.resumeRequest = null;
         this.createResumeInputs();
+    }
+
+    get activeBatch() {
+        const uploads = this.app.store.getState().uploads;
+        return uploads.activeBatchId ? uploads.batches.get(uploads.activeBatchId) : null;
+    }
+    get activeUploadSession() { return this.activeBatch?.session || null; }
+    set activeUploadSession(session) {
+        if (!session) {
+            this.app.store.update('uploads', { activeBatchId: null, batches: new Map(), status: 'idle' }, 'UPLOAD_BATCH_CHANGED');
+            return;
+        }
+        const id = crypto.randomUUID();
+        const batch = { id, session, progress: new Map(), stats: null, status: 'running' };
+        this.app.store.update('uploads', { activeBatchId: id, batches: new Map([[id, batch]]), status: 'running' }, 'UPLOAD_BATCH_CHANGED');
+    }
+    get progress() { return this.activeBatch?.progress || new Map(); }
+    get uploadStats() { return this.activeBatch?.stats || null; }
+    set uploadStats(stats) {
+        const batch = this.activeBatch;
+        if (!batch) return;
+        const updated = { ...batch, stats };
+        this.app.store.update('uploads', { batches: new Map([[batch.id, updated]]) }, 'UPLOAD_STATS_CHANGED');
     }
 
     createUploadSession() {


### PR DESCRIPTION
## Summary
- add a single Store for route, directory, selection, search, editor, uploads, and UI state
- make Router publish route state instead of keeping a duplicate route object
- derive Aria2 and Uploads page modes from route state
- move directory request generations, loading counts, editor revisions, search cursors, and upload batches into the Store
- add frontend Store tests and execute them in CI

## Tests
- npm test
- go test ./...
- go vet ./...
- node --check for all changed JavaScript modules
- git diff --check