### PR TITLE
refactor: share polling page lifecycle

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -63,10 +63,11 @@ export class ApiClient {
         context = url,
         fallbackMessage = 'Request failed',
         toastOnError = true,
-        validateSuccess = false
+        validateSuccess = false,
+        signal
     } = {}) {
         try {
-            const response = await fetch(url);
+            const response = await fetch(url, { signal });
             if (!response.ok) {
                 let apiError = null;
                 try {
@@ -83,6 +84,7 @@ export class ApiClient {
             }
             return result;
         } catch (error) {
+            if (error.name === 'AbortError') return null;
             if (toastOnError) {
                 this.notifyApiError(error.message || fallbackMessage, { error, context });
             } else {
@@ -601,11 +603,12 @@ export class ApiClient {
         return result.data;
     }
 
-    async getAria2cStatus() {
+    async getAria2cStatus(signal) {
         const result = await this.requestJson('/api/system/aria2c/status', {
             context: 'fetching aria2c status',
             fallbackMessage: 'Failed to fetch aria2c status',
-            validateSuccess: true
+            validateSuccess: true,
+            signal
         });
         if (!result) {
             return null;

--- a/static/js/aria2c-page.js
+++ b/static/js/aria2c-page.js
@@ -1,13 +1,23 @@
 import { getTemplateContent } from './template.js';
+import { PollingPageController } from './polling-page-controller.js';
 
 export class Aria2cPageHandler {
     constructor(fileManager) {
         this.fileManager = fileManager;
-        this.pollEnabled = false;
         this.previousPath = '/'; // Store the path before entering this page
         this.torrentsToCancel = new Set(); // Track torrents scheduled for cancellation
-        this.polling = false;
-        this.pollTimer = null;
+        this.initialLoadPending = false;
+        this.poller = new PollingPageController({
+            interval: 2000,
+            isCurrentPage: () => this.isInAria2cMode,
+            fetchData: signal => this.fileManager.api.getAria2cStatus(signal),
+            render: status => this.render(status),
+            onSettled: () => {
+                if (!this.initialLoadPending) return;
+                this.initialLoadPending = false;
+                this.fileManager.ui.hideLoading();
+            }
+        });
     }
 
     get isInAria2cMode() {
@@ -19,25 +29,23 @@ export class Aria2cPageHandler {
     }
 
     enterAria2cMode() {
-        if (this.pollEnabled) return;
+        if (this.poller.active) return;
 
         const currentPath = this.fileManager.router.getCurrentPath();
         if (currentPath !== '/system/aria2c') {
             this.previousPath = currentPath;
         }
 
-        this.pollEnabled = true;
+        this.initialLoadPending = true;
         this.fileManager.ui.showLoading();
-        this.loadAria2cStatus();
+        this.poller.start();
         
         const breadcrumbs = document.querySelector('.breadcrumbs');
         if (breadcrumbs) breadcrumbs.style.display = 'none';
     }
 
     exitAria2cMode(navigate = true) {
-        if (!this.pollEnabled) return;
-        this.pollEnabled = false;
-        clearTimeout(this.pollTimer);
+        if (!this.poller.stop()) return;
 
         const breadcrumbs = document.querySelector('.breadcrumbs');
         if (breadcrumbs) breadcrumbs.style.display = '';
@@ -46,22 +54,7 @@ export class Aria2cPageHandler {
     }
 
     async loadAria2cStatus() {
-        if (!this.pollEnabled || !this.isInAria2cMode || this.polling) return;
-        this.polling = true;
-        try {
-            const status = await this.fileManager.api.getAria2cStatus();
-            if (status) {
-                if (this.isInAria2cMode && this.fileManager.router.getCurrentPath() === '/system/aria2c') this.render(status);
-            } else {
-                // API method failed and should have shown a toast.
-                // Stop polling.
-                this.pollEnabled = false;
-            }
-        } finally {
-            this.polling = false;
-            this.fileManager.ui.hideLoading();
-            if (this.pollEnabled && this.isInAria2cMode) this.pollTimer = setTimeout(() => this.loadAria2cStatus(), 2000);
-        }
+        await this.poller.refresh();
     }
 
     render(status) {

--- a/static/js/polling-page-controller.js
+++ b/static/js/polling-page-controller.js
@@ -1,0 +1,55 @@
+export class PollingPageController {
+    constructor({ interval, isCurrentPage, fetchData, render, onError = console.error, onSettled = () => {} }) {
+        this.interval = interval;
+        this.isCurrentPage = isCurrentPage;
+        this.fetchData = fetchData;
+        this.render = render;
+        this.onError = onError;
+        this.onSettled = onSettled;
+        this.active = false;
+        this.polling = false;
+        this.timer = null;
+        this.controller = null;
+    }
+
+    start() {
+        if (this.active) return false;
+        this.active = true;
+        void this.refresh();
+        return true;
+    }
+
+    stop() {
+        if (!this.active) return false;
+        this.active = false;
+        clearTimeout(this.timer);
+        this.timer = null;
+        this.controller?.abort();
+        this.controller = null;
+        return true;
+    }
+
+    async refresh() {
+        if (!this.active || !this.isCurrentPage() || this.polling) return;
+        this.polling = true;
+        const controller = new AbortController();
+        this.controller = controller;
+        try {
+            const data = await this.fetchData(controller.signal);
+            if (data == null) {
+                this.stop();
+                return;
+            }
+            if (this.active && this.isCurrentPage() && !controller.signal.aborted) this.render(data);
+        } catch (error) {
+            if (error.name !== 'AbortError') this.onError(error);
+        } finally {
+            if (this.controller === controller) this.controller = null;
+            this.polling = false;
+            this.onSettled();
+            if (this.active && this.isCurrentPage()) {
+                this.timer = setTimeout(() => this.refresh(), this.interval);
+            }
+        }
+    }
+}

--- a/static/js/polling-page-controller.test.mjs
+++ b/static/js/polling-page-controller.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { PollingPageController } from './polling-page-controller.js';
+
+test('prevents overlapping polls and renders current page data', async () => {
+    let resolveFetch;
+    let calls = 0;
+    const rendered = [];
+    const polling = new PollingPageController({
+        interval: 60000,
+        isCurrentPage: () => true,
+        fetchData: () => {
+            calls += 1;
+            return new Promise(resolve => { resolveFetch = resolve; });
+        },
+        render: data => rendered.push(data)
+    });
+
+    polling.start();
+    await polling.refresh();
+    assert.equal(calls, 1);
+    resolveFetch(['job']);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.deepEqual(rendered, [['job']]);
+    polling.stop();
+});
+
+test('aborts an in-flight request when stopped', async () => {
+    let signal;
+    const polling = new PollingPageController({
+        interval: 60000,
+        isCurrentPage: () => true,
+        fetchData: requestSignal => {
+            signal = requestSignal;
+            return new Promise(() => {});
+        },
+        render: () => {}
+    });
+
+    polling.start();
+    polling.stop();
+    assert.equal(signal.aborted, true);
+});

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -3,11 +3,14 @@
 export class UploadPageHandler {
     constructor(app) {
         this.app = app;
-        this.pollEnabled = false;
         this.selectedKeys = new Set();
-        this.polling = false;
-        this.timer = null;
-        this.refreshController = null;
+        this.poller = new PollingPageController({
+            interval: 3000,
+            isCurrentPage: () => this.isActive,
+            fetchData: signal => this.app.uploader.listJobs(signal),
+            render: jobs => this.render(jobs),
+            onError: error => console.error('Failed to refresh uploads', error)
+        });
         this.onJobsChanged = () => this.refresh();
     }
 
@@ -16,38 +19,19 @@ export class UploadPageHandler {
     }
 
     enter() {
-        if (this.pollEnabled) return;
-        this.pollEnabled = true;
+        if (!this.poller.start()) return;
         window.addEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
-        this.refresh();
         document.querySelector('.breadcrumbs')?.style.setProperty('display', 'none');
     }
 
     exit() {
-        if (!this.pollEnabled) return;
-        this.pollEnabled = false;
-        clearTimeout(this.timer);
-        this.refreshController?.abort();
-        this.refreshController = null;
+        if (!this.poller.stop()) return;
         window.removeEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
         document.querySelector('.breadcrumbs')?.style.removeProperty('display');
     }
 
     async refresh() {
-        if (!this.pollEnabled || !this.isActive || this.polling) return;
-        this.polling = true;
-        const controller = new AbortController();
-        this.refreshController = controller;
-        try {
-            const jobs = await this.app.uploader.listJobs(controller.signal);
-            if (this.pollEnabled && this.isActive && !controller.signal.aborted) this.render(jobs);
-        } catch (error) {
-            if (error.name !== 'AbortError') console.error('Failed to refresh uploads', error);
-        } finally {
-            if (this.refreshController === controller) this.refreshController = null;
-            this.polling = false;
-            if (this.pollEnabled && this.isActive) this.timer = setTimeout(() => this.refresh(), 3000);
-        }
+        await this.poller.refresh();
     }
 
     render(jobs) {
@@ -136,3 +120,4 @@ export class UploadPageHandler {
         await this.refresh();
     }
 }
+import { PollingPageController } from './polling-page-controller.js';


### PR DESCRIPTION
## Summary
- add a reusable polling page controller with overlap prevention and cancellation
- migrate the Aria2 and resumable uploads pages to the shared lifecycle
- abort in-flight status requests when leaving a page
- add frontend tests for rendering and cancellation behavior

## Tests
- node --check static/js/polling-page-controller.js
- node --check static/js/aria2c-page.js
- node --check static/js/upload-page.js
- node --check static/js/api.js
- npm test
- go test ./...
- go vet ./...
- git diff --check