### PR TITLE
fix: support browsers without randomUUID

### DIFF
--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -17,7 +17,7 @@ export function createModalOverlay({ className = '', hidden = false, content = n
 
     const title = modal.querySelector('.modal-title, .editor-title, h1, h2');
     if (title) {
-        title.id ||= `modal-title-${crypto.randomUUID()}`;
+        title.id ||= `modal-title-${createUniqueId()}`;
         modal.setAttribute('aria-labelledby', title.id);
     } else {
         modal.setAttribute('aria-label', 'Dialog');
@@ -120,7 +120,7 @@ function createDialogShell({ title = '', description = '' } = {}) {
     header.className = 'app-dialog__header';
 
     const titleElement = document.createElement('h2');
-    titleElement.id = `dialog-title-${crypto.randomUUID()}`;
+    titleElement.id = `dialog-title-${createUniqueId()}`;
     titleElement.className = 'app-dialog__title';
     titleElement.textContent = title;
     header.appendChild(titleElement);
@@ -130,7 +130,7 @@ function createDialogShell({ title = '', description = '' } = {}) {
 
     if (description) {
         const descriptionElement = document.createElement('p');
-        descriptionElement.id = `dialog-description-${crypto.randomUUID()}`;
+        descriptionElement.id = `dialog-description-${createUniqueId()}`;
         descriptionElement.className = 'app-dialog__description';
         descriptionElement.textContent = description;
         form.appendChild(descriptionElement);
@@ -237,3 +237,4 @@ export function showPromptDialog({
         input.select();
     });
 }
+import { createUniqueId } from './util.js';

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -121,7 +121,7 @@ export class Uploader {
             this.app.store.update('uploads', { activeBatchId: null, batches: new Map(), status: 'idle' }, 'UPLOAD_BATCH_CHANGED');
             return;
         }
-        const id = crypto.randomUUID();
+        const id = createUniqueId();
         const batch = { id, session, progress: new Map(), stats: null, status: 'running' };
         this.app.store.update('uploads', { activeBatchId: id, batches: new Map([[id, batch]]), status: 'running' }, 'UPLOAD_BATCH_CHANGED');
     }
@@ -557,3 +557,4 @@ export class Uploader {
         this.app.ui.showToast('Upload error', message, 'error');
     }
 }
+import { createUniqueId } from './util.js';

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1,3 +1,20 @@
+let uniqueIdCounter = 0;
+
+export function createUniqueId(cryptoProvider = globalThis.crypto) {
+    if (typeof cryptoProvider?.randomUUID === 'function') return cryptoProvider.randomUUID();
+
+    if (typeof cryptoProvider?.getRandomValues === 'function') {
+        const bytes = cryptoProvider.getRandomValues(new Uint8Array(16));
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        const hex = [...bytes].map(value => value.toString(16).padStart(2, '0'));
+        return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+    }
+
+    uniqueIdCounter += 1;
+    return `${Date.now().toString(36)}-${uniqueIdCounter.toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 export function normalizePath(path) {
     if (!path || path === '/') return '/';
     const parts = path.split('/').filter(part => part !== '' && part !== '.');

--- a/static/js/util.test.mjs
+++ b/static/js/util.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createUniqueId } from './util.js';
+
+test('uses randomUUID when it is available', () => {
+    assert.equal(createUniqueId({ randomUUID: () => 'native-id' }), 'native-id');
+});
+
+test('creates an RFC 4122 shaped id from getRandomValues', () => {
+    const id = createUniqueId({ getRandomValues: bytes => bytes.fill(0) });
+    assert.match(id, /^00000000-0000-4000-8000-000000000000$/);
+});
+
+test('creates distinct ids without Web Crypto', () => {
+    assert.notEqual(createUniqueId(null), createUniqueId(null));
+});


### PR DESCRIPTION
## Summary
- add a unique ID helper that works without crypto.randomUUID
- use getRandomValues when available and a local fallback otherwise
- migrate modal accessibility IDs and upload batch IDs to the helper
- cover native, Web Crypto fallback, and legacy browser paths

## Tests
- node --check static/js/util.js
- node --check static/js/modal.js
- node --check static/js/uploader.js
- npm test
- npm run build
- go test ./...
- go vet ./...
- git diff --check