### PR TITLE
refactor: centralize template registry

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -13,6 +13,7 @@ import { Aria2cPageHandler } from './aria2c-page.js';
 import { UploadPageHandler } from './upload-page.js';
 import { loadTemplates } from './template.js';
 import { AppStateStore } from './state.js';
+import { ALL_TEMPLATES } from './template-registry.js';
 
 class FileManagerApp {
     constructor() {
@@ -197,38 +198,7 @@ class FileManagerApp {
 }
 
 async function main() {
-    const templatePaths = [
-        '/static/templates/components/toolbar.html',
-        '/static/templates/components/upload_area.html',
-        '/static/templates/components/empty_state.html',
-        '/static/templates/components/view_toggle.html',
-        '/static/templates/components/list_view_header.html',
-        '/static/templates/components/list_view_item.html',
-        '/static/templates/components/grid_view_item.html',
-        '/static/templates/components/file_actions.html',
-        '/static/templates/components/folder_actions.html',
-        '/static/templates/components/toast.html',
-        '/static/templates/components/nav_item.html',
-        '/static/templates/components/masonry_item.html',
-        '/static/templates/components/progress_overlay.html',
-        '/static/templates/components/aria2c_header.html',
-        '/static/templates/components/aria2c_no_downloads.html',
-        '/static/templates/components/aria2c_table.html',
-        '/static/templates/components/aria2c_table_row.html',
-        '/static/templates/components/upload_page_header.html',
-        '/static/templates/components/upload_page_empty.html',
-        '/static/templates/components/upload_page_section.html',
-        '/static/templates/components/upload_page_table.html',
-        '/static/templates/components/upload_page_row.html',
-        '/static/templates/components/image_viewer.html',
-        '/static/templates/components/completion_dropdown.html',
-        '/static/templates/components/completion_item.html',
-        '/static/templates/components/search_modal.html',
-        '/static/templates/components/search_results_header.html',
-        '/static/templates/components/search_no_results.html',
-        '/static/templates/components/video_view_item.html'
-    ];
-    await loadTemplates(templatePaths);
+    await loadTemplates(ALL_TEMPLATES);
 
     const app = new FileManagerApp();
     await app.init();

--- a/static/js/aria2c-page.js
+++ b/static/js/aria2c-page.js
@@ -1,5 +1,6 @@
 import { getTemplateContent } from './template.js';
 import { PollingPageController } from './polling-page-controller.js';
+import { TEMPLATES } from './template-registry.js';
 
 export class Aria2cPageHandler {
     constructor(fileManager) {
@@ -113,7 +114,7 @@ export class Aria2cPageHandler {
     createHeader() {
         const header = document.createElement('div');
         header.className = 'aria2c-header';
-        const template = getTemplateContent('/static/templates/components/aria2c_header.html');
+        const template = getTemplateContent(TEMPLATES.aria2Header);
         header.appendChild(template);
         header.querySelector('.aria2c-back-btn').addEventListener('click', () => this.exitAria2cMode());
         return header;
@@ -122,7 +123,7 @@ export class Aria2cPageHandler {
     createNoDownloadsMessage() {
         const noResults = document.createElement('div');
         noResults.className = 'no-search-results';
-        const template = getTemplateContent('/static/templates/components/aria2c_no_downloads.html');
+        const template = getTemplateContent(TEMPLATES.aria2Empty);
         noResults.appendChild(template);
         return noResults;
     }
@@ -146,7 +147,7 @@ export class Aria2cPageHandler {
     createTable(downloads, isActive) {
         const table = document.createElement('table');
         table.className = 'table-view aria2c-table';
-        const template = getTemplateContent('/static/templates/components/aria2c_table.html');
+        const template = getTemplateContent(TEMPLATES.aria2Table);
         table.appendChild(template);
         
         const tbody = table.querySelector('tbody');
@@ -161,7 +162,7 @@ export class Aria2cPageHandler {
         const tr = document.createElement('tr');
         tr.dataset.gid = item.gid;
 
-        const template = getTemplateContent('/static/templates/components/aria2c_table_row.html');
+        const template = getTemplateContent(TEMPLATES.aria2Row);
         const fileName = item.files && item.files.length > 0 ? this.getFileName(item.files[0].path) : 'N/A';
         const totalLength = parseInt(item.totalLength, 10);
         const completedLength = parseInt(item.completedLength, 10);

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,4 +1,5 @@
 import { getTemplateContent } from './template.js';
+import { TEMPLATES } from './template-registry.js';
 import { createModalOverlay, bindModalClose, hideModalOverlay, showModalOverlay } from './modal.js';
 import { buildApiUrl } from './util.js';
 import { ImageLoader } from './image-loader.js';
@@ -18,7 +19,7 @@ export class ImageViewer {
     }
     
     createViewerElement() {
-        const template = getTemplateContent('/static/templates/components/image_viewer.html');
+        const template = getTemplateContent(TEMPLATES.imageViewer);
         const viewer = createModalOverlay({ className: 'image-viewer', hidden: true, content: template });
         this.viewerElement = viewer;
         this.imageElement = viewer.querySelector('img');

--- a/static/js/progress.js
+++ b/static/js/progress.js
@@ -1,4 +1,5 @@
 import { getTemplateContent } from './template.js';
+import { TEMPLATES } from './template-registry.js';
 
 export class ProgressManager {
     constructor() {
@@ -18,7 +19,7 @@ export class ProgressManager {
     createProgressOverlay() {
         const overlay = document.createElement('div');
         overlay.className = 'progress-overlay';
-        const template = getTemplateContent('/static/templates/components/progress_overlay.html');
+        const template = getTemplateContent(TEMPLATES.progressOverlay);
         overlay.appendChild(template);
 
         document.body.appendChild(overlay);

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,5 +1,6 @@
 import { getTemplateContent } from './template.js';
 import { createModalOverlay, bindModalClose, hideModalOverlay, showModalOverlay } from './modal.js';
+import { TEMPLATES } from './template-registry.js';
 
 export class SearchHandler {
     constructor(fileManager) {
@@ -62,7 +63,7 @@ export class SearchHandler {
         const dropdown = document.createElement('div');
         dropdown.className = 'cd-completion-dropdown';
         dropdown.style.display = 'none';
-        const template = getTemplateContent('/static/templates/components/completion_dropdown.html');
+        const template = getTemplateContent(TEMPLATES.completionDropdown);
         dropdown.appendChild(template);
         document.querySelector('.search-container')?.appendChild(dropdown);
         this.completionDropdown = dropdown;
@@ -249,7 +250,7 @@ export class SearchHandler {
         completions.forEach((completion, index) => {
             const li = document.createElement('li');
             li.className = 'completion-item';
-            const template = getTemplateContent('/static/templates/components/completion_item.html');
+            const template = getTemplateContent(TEMPLATES.completionItem);
             template.querySelector('.completion-name').textContent = completion.name;
             template.querySelector('.completion-path').textContent = completion.fullPath;
             li.appendChild(template);
@@ -305,7 +306,7 @@ export class SearchHandler {
     }
 
     createSearchModal() {
-        const template = getTemplateContent('/static/templates/components/search_modal.html');
+        const template = getTemplateContent(TEMPLATES.searchModal);
         const modal = createModalOverlay({ className: 'search-modal', hidden: true, content: template });
         this.searchModal = modal;
 
@@ -444,7 +445,7 @@ export class SearchHandler {
 
         const header = document.createElement('div');
         header.className = 'search-results-header';
-        const headerTemplate = getTemplateContent('/static/templates/components/search_results_header.html');
+        const headerTemplate = getTemplateContent(TEMPLATES.searchResultsHeader);
         headerTemplate.querySelector('.search-results-count div').textContent = `Search Results for "${searchTerm}"`;
         headerTemplate.querySelector('.pagination-info').textContent = results.length
             ? `Page ${page + 1} · Showing ${startIndex + 1}-${endIndex}${this.hasMore ? '+' : ''}`
@@ -467,7 +468,7 @@ export class SearchHandler {
         if (results.length === 0) {
             const noResults = document.createElement('div');
             noResults.className = 'no-search-results';
-            const noResultsTemplate = getTemplateContent('/static/templates/components/search_no_results.html');
+            const noResultsTemplate = getTemplateContent(TEMPLATES.searchNoResults);
             noResultsTemplate.querySelector('.no-search-results-text').textContent = `No files found matching "${searchTerm}"`;
             noResults.appendChild(noResultsTemplate);
             container.appendChild(noResults);

--- a/static/js/template-registry.js
+++ b/static/js/template-registry.js
@@ -1,0 +1,54 @@
+const component = name => `/static/templates/components/${name}.html`;
+
+export const TEMPLATES = Object.freeze({
+    toolbar: component('toolbar'),
+    uploadArea: component('upload_area'),
+    emptyState: component('empty_state'),
+    viewToggle: component('view_toggle'),
+    listViewHeader: component('list_view_header'),
+    listViewItem: component('list_view_item'),
+    gridViewItem: component('grid_view_item'),
+    masonryItem: component('masonry_item'),
+    videoViewItem: component('video_view_item'),
+    fileActions: component('file_actions'),
+    folderActions: component('folder_actions'),
+    toast: component('toast'),
+    navItem: component('nav_item'),
+    progressOverlay: component('progress_overlay'),
+    imageViewer: component('image_viewer'),
+    aria2Header: component('aria2c_header'),
+    aria2Empty: component('aria2c_no_downloads'),
+    aria2Table: component('aria2c_table'),
+    aria2Row: component('aria2c_table_row'),
+    uploadHeader: component('upload_page_header'),
+    uploadEmpty: component('upload_page_empty'),
+    uploadSection: component('upload_page_section'),
+    uploadTable: component('upload_page_table'),
+    uploadRow: component('upload_page_row'),
+    completionDropdown: component('completion_dropdown'),
+    completionItem: component('completion_item'),
+    searchModal: component('search_modal'),
+    searchResultsHeader: component('search_results_header'),
+    searchNoResults: component('search_no_results')
+});
+
+export const TEMPLATE_GROUPS = Object.freeze({
+    directory: Object.freeze([
+        TEMPLATES.toolbar, TEMPLATES.uploadArea, TEMPLATES.emptyState, TEMPLATES.viewToggle,
+        TEMPLATES.listViewHeader, TEMPLATES.listViewItem, TEMPLATES.gridViewItem,
+        TEMPLATES.masonryItem, TEMPLATES.videoViewItem, TEMPLATES.fileActions,
+        TEMPLATES.folderActions, TEMPLATES.navItem
+    ]),
+    systemPages: Object.freeze([
+        TEMPLATES.aria2Header, TEMPLATES.aria2Empty, TEMPLATES.aria2Table, TEMPLATES.aria2Row,
+        TEMPLATES.uploadHeader, TEMPLATES.uploadEmpty, TEMPLATES.uploadSection,
+        TEMPLATES.uploadTable, TEMPLATES.uploadRow
+    ]),
+    search: Object.freeze([
+        TEMPLATES.completionDropdown, TEMPLATES.completionItem, TEMPLATES.searchModal,
+        TEMPLATES.searchResultsHeader, TEMPLATES.searchNoResults
+    ]),
+    overlays: Object.freeze([TEMPLATES.toast, TEMPLATES.progressOverlay, TEMPLATES.imageViewer])
+});
+
+export const ALL_TEMPLATES = Object.freeze([...new Set(Object.values(TEMPLATE_GROUPS).flat())]);

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,6 +1,7 @@
 import { getTemplateContent } from './template.js';
 import { buildApiUrl } from './util.js';
 import { ImageLoader } from './image-loader.js';
+import { TEMPLATES } from './template-registry.js';
 
 export class UIManager {
     constructor(app) {
@@ -106,7 +107,7 @@ export class UIManager {
         if (!this.fileBrowserExtensionsVisible) {
             toolbar.classList.add('hidden');
         }
-        const template = getTemplateContent('/static/templates/components/toolbar.html');
+        const template = getTemplateContent(TEMPLATES.toolbar);
         toolbar.appendChild(template);
         container.appendChild(toolbar);
     }
@@ -117,7 +118,7 @@ export class UIManager {
         if (!this.fileBrowserExtensionsVisible) {
             uploadArea.classList.add('hidden');
         }
-        const template = getTemplateContent('/static/templates/components/upload_area.html');
+        const template = getTemplateContent(TEMPLATES.uploadArea);
         template.querySelector('.upload-path').textContent = this.app.router.getCurrentPath();
         uploadArea.appendChild(template);
         container.appendChild(uploadArea);
@@ -126,7 +127,7 @@ export class UIManager {
     renderEmptyState(container) {
         const noFiles = document.createElement('div');
         noFiles.className = 'no-files';
-        const template = getTemplateContent('/static/templates/components/empty_state.html');
+        const template = getTemplateContent(TEMPLATES.emptyState);
         noFiles.appendChild(template);
         container.appendChild(noFiles);
     }
@@ -174,7 +175,7 @@ export class UIManager {
     createViewToggle(hasMasonrySupport = false, hasVideoSupport = false) {
         const viewToggle = document.createElement('div');
         viewToggle.className = 'view-toggle';
-        const template = getTemplateContent('/static/templates/components/view_toggle.html');
+        const template = getTemplateContent(TEMPLATES.viewToggle);
         
         const activeBtn = template.querySelector(`[data-view="${this.viewMode}"]`);
         if (activeBtn) {
@@ -230,7 +231,7 @@ export class UIManager {
     }
 
     createVideoItem(file) {
-        const template = getTemplateContent('/static/templates/components/video_view_item.html');
+        const template = getTemplateContent(TEMPLATES.videoViewItem);
         const videoItem = template.querySelector('.video-card');
         this.setFileItemData(videoItem, file);
 
@@ -385,7 +386,7 @@ export class UIManager {
 
     createListViewHeader(sortField, sortDirection) {
         const thead = document.createElement('thead');
-        const headerTemplate = getTemplateContent('/static/templates/components/list_view_header.html');
+        const headerTemplate = getTemplateContent(TEMPLATES.listViewHeader);
         const headerRow = headerTemplate.querySelector('tr');
         
         const sortableHeader = headerRow.querySelector(`[data-sort="${sortField}"]`);
@@ -542,7 +543,7 @@ export class UIManager {
         tr.className = 'file-item';
         this.setFileItemData(tr, file);
 
-        const template = getTemplateContent('/static/templates/components/list_view_item.html');
+        const template = getTemplateContent(TEMPLATES.listViewItem);
         template.querySelector('.file-icon').className = `file-icon ${this.getFileIconClass(file)}`;
         template.querySelector('.file-name').textContent = file.name;
         template.querySelector('.file-size').textContent = file.is_dir ? '-' : this.formatFileSize(file.size);
@@ -561,7 +562,7 @@ export class UIManager {
         item.className = 'masonry-item';
         this.setFileItemData(item, file);
 
-        const template = getTemplateContent('/static/templates/components/masonry_item.html');
+        const template = getTemplateContent(TEMPLATES.masonryItem);
         const img = template.querySelector('.masonry-image');
         
         img.alt = file.name;
@@ -606,7 +607,7 @@ export class UIManager {
         fileItem.className = 'file-item';
         this.setFileItemData(fileItem, file);
 
-        const template = getTemplateContent('/static/templates/components/grid_view_item.html');
+        const template = getTemplateContent(TEMPLATES.gridViewItem);
         template.querySelector('.file-icon').className = `file-icon ${this.getFileIconClass(file)}`;
         template.querySelector('.file-name').textContent = file.name;
         template.querySelector('.file-info').textContent = file.is_dir ? 'Folder' : this.formatFileSize(file.size);
@@ -619,7 +620,7 @@ export class UIManager {
     }
     
     renderFileActions(container, file) {
-        const templateFile = file.is_dir ? '/static/templates/components/folder_actions.html' : '/static/templates/components/file_actions.html';
+        const templateFile = file.is_dir ? TEMPLATES.folderActions : TEMPLATES.fileActions;
         const template = getTemplateContent(templateFile);
 
         if (!file.is_dir) {
@@ -723,7 +724,7 @@ export class UIManager {
         toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
         toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
         toast.setAttribute('aria-atomic', 'true');
-        const template = getTemplateContent('/static/templates/components/toast.html');
+        const template = getTemplateContent(TEMPLATES.toast);
         template.querySelector('.toast-title').textContent = title;
         template.querySelector('.toast-message').textContent = message;
         toast.appendChild(template);
@@ -766,7 +767,7 @@ export class UIManager {
             navItem.className = 'nav-item';
             navItem.dataset.path = dir.path;
             
-            const template = getTemplateContent('/static/templates/components/nav_item.html');
+            const template = getTemplateContent(TEMPLATES.navItem);
             template.querySelector('i').textContent = iconMap[dir.name] || iconMap['default'];
             template.querySelector('span').textContent = dir.name;
             navItem.appendChild(template);

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -1,7 +1,15 @@
 import { PollingPageController } from './polling-page-controller.js';
 import { getTemplateContent } from './template.js';
+import { TEMPLATES } from './template-registry.js';
 
-const template = name => getTemplateContent(`/static/templates/components/upload_page_${name}.html`);
+const uploadTemplates = {
+    header: TEMPLATES.uploadHeader,
+    empty: TEMPLATES.uploadEmpty,
+    section: TEMPLATES.uploadSection,
+    table: TEMPLATES.uploadTable,
+    row: TEMPLATES.uploadRow
+};
+const template = name => getTemplateContent(uploadTemplates[name]);
 
 // Uploads page deliberately shares aria2c's table classes: transfers have the
 // same lifecycle (active, paused, complete) even though their transport differs.


### PR DESCRIPTION
## Summary
- define every component template URL in one registry
- group templates by directory, system page, search, and overlay consumers
- load the deduplicated registry during startup
- replace component-local string paths with shared constants

## Tests
- node --check for all changed JavaScript modules
- npm test
- npm run build
- go test ./...
- go vet ./...
- git diff --check