### PR TITLE
refactor: replace util service with pure functions

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,5 +1,5 @@
 import { showConfirmDialog, showPromptDialog } from './modal.js';
-import { buildApiUrl } from './util.js';
+import { buildApiUrl, getBaseName, getParentPath, isEditableFile, isValidPath } from './util.js';
 
 const MAX_CACHED_DIRECTORIES = 20;
 const MAX_CACHED_ENTRIES = 100000;
@@ -265,12 +265,12 @@ export class ApiClient {
         const newName = await showPromptDialog({
             title: 'Rename File',
             message: 'Enter a new name.',
-            defaultValue: this.app.util.getBaseName(path),
+            defaultValue: getBaseName(path),
             confirmLabel: 'Rename'
         });
         if (!newName) return;
         
-        const newPath = this.app.util.getParentPath(path) + '/' + newName;
+        const newPath = getParentPath(path) + '/' + newName;
 
         await this.runMutation({
             endpoint: '/api/files/move',
@@ -284,9 +284,9 @@ export class ApiClient {
     }
 
     async moveFile(sourcePath) {
-        const fileName = this.app.util.getBaseName(sourcePath);
+        const fileName = getBaseName(sourcePath);
         const currentPath = this.app.router.getCurrentPath();
-        const suggestedPath = currentPath !== '/' ? currentPath : this.app.util.getParentPath(sourcePath);
+        const suggestedPath = currentPath !== '/' ? currentPath : getParentPath(sourcePath);
         
         const targetDir = await showPromptDialog({
             title: 'Move File',
@@ -296,7 +296,7 @@ export class ApiClient {
         });
         if (!targetDir) return;
         
-        if (!this.app.util.isValidPath(targetDir)) {
+        if (!isValidPath(targetDir)) {
             this.app.ui.showToast('Error', 'Invalid target path', 'error');
             return;
         }
@@ -317,7 +317,7 @@ export class ApiClient {
             errorMessage: 'Failed to move file',
             showLoading: true,
             onSuccess: async () => {
-                await this.refreshCurrentDirectory([this.app.util.getParentPath(sourcePath), targetDir]);
+                await this.refreshCurrentDirectory([getParentPath(sourcePath), targetDir]);
             },
             logContext: 'moving file'
         });
@@ -337,7 +337,7 @@ export class ApiClient {
     async moveMultipleFiles() {
         const firstFile = Array.from(this.app.selectedFiles)[0];
         const currentPath = this.app.router.getCurrentPath();
-        const suggestedPath = currentPath !== '/' ? currentPath : this.app.util.getParentPath(firstFile);
+        const suggestedPath = currentPath !== '/' ? currentPath : getParentPath(firstFile);
         
         const targetDir = await showPromptDialog({
             title: 'Move Selected Items',
@@ -347,7 +347,7 @@ export class ApiClient {
         });
         if (!targetDir) return;
         
-        if (!this.app.util.isValidPath(targetDir)) {
+        if (!isValidPath(targetDir)) {
             this.app.ui.showToast('Error', 'Invalid target path', 'error');
             return;
         }
@@ -358,7 +358,7 @@ export class ApiClient {
             let failCount = 0;
             
             for (const sourcePath of this.app.selectedFiles) {
-                const fileName = this.app.util.getBaseName(sourcePath);
+                const fileName = getBaseName(sourcePath);
                 const targetPath = targetDir.endsWith('/') ? 
                     targetDir + fileName : 
                     targetDir + '/' + fileName;
@@ -435,7 +435,7 @@ export class ApiClient {
             errorMessage: 'Failed to create file',
             onSuccess: async (result) => {
                 await this.refreshCurrentDirectory();
-                if (this.app.util.isEditableFile(result.data.path)) {
+                if (isEditableFile(result.data.path)) {
                     setTimeout(() => {
                         this.app.editFile(result.data.path);
                     }, 500);
@@ -448,7 +448,7 @@ export class ApiClient {
     async extractFile(path) {
         const confirmed = await showConfirmDialog({
             title: 'Extract Archive',
-            message: `Are you sure you want to extract "${this.app.util.getBaseName(path)}"?`,
+            message: `Are you sure you want to extract "${getBaseName(path)}"?`,
             confirmLabel: 'Extract'
         });
         if (!confirmed) return;
@@ -467,7 +467,7 @@ export class ApiClient {
     async deleteFile(path) {
         const confirmed = await showConfirmDialog({
             title: 'Delete File',
-            message: `Are you sure you want to delete "${this.app.util.getBaseName(path)}"?`,
+            message: `Are you sure you want to delete "${getBaseName(path)}"?`,
             confirmLabel: 'Delete',
             danger: true
         });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -8,7 +8,6 @@ import { UIManager } from './ui.js';
 import { ApiClient } from './api.js';
 import { EventHandler } from './events.js';
 import { Uploader } from './uploader.js';
-import { Util } from './util.js';
 import { Aria2cPageHandler } from './aria2c-page.js';
 import { UploadPageHandler } from './upload-page.js';
 import { loadTemplates } from './template.js';
@@ -25,7 +24,6 @@ class FileManagerApp {
 
         // Initialize modules that don't depend on templates in their constructor
         this.router = new Router(this.store);
-        this.util = new Util(this);
         this.api = new ApiClient(this);
         this.uploader = new Uploader(this);
         this.events = new EventHandler(this);

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,6 +1,7 @@
 import { getTemplateContent } from './template.js';
 import { createModalOverlay, bindModalClose, hideModalOverlay, showModalOverlay } from './modal.js';
 import { TEMPLATES } from './template-registry.js';
+import { getParentPath, normalizePath } from './util.js';
 
 export class SearchHandler {
     constructor(fileManager) {
@@ -143,14 +144,14 @@ export class SearchHandler {
         try {
             let targetPath = '/';
             if (path && path !== '') {
-                if (path === '..') targetPath = this.fileManager.util.getParentPath(this.fileManager.router.getCurrentPath());
+                if (path === '..') targetPath = getParentPath(this.fileManager.router.getCurrentPath());
                 else if (path.startsWith('/')) targetPath = path;
                 else {
                     const basePath = this.fileManager.router.getCurrentPath();
                     targetPath = basePath.endsWith('/') ? basePath + path : `${basePath}/${path}`;
                 }
             }
-            await this.navigateToFolder(this.fileManager.util.normalizePath(targetPath));
+            await this.navigateToFolder(normalizePath(targetPath));
         } catch (error) {
             this.fileManager.ui.showToast('cd Error', `Cannot change directory: ${error.message}`, 'error');
         }
@@ -181,7 +182,7 @@ export class SearchHandler {
 
     async navigateToFolder(path) {
         try {
-            const normalizedPath = this.fileManager.util.normalizePath(path);
+            const normalizedPath = normalizePath(path);
             const result = await this.fileManager.api.getFiles(normalizedPath, { useCache: false });
             if (result) {
                 this.exitSearchMode(true);

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -52,34 +52,24 @@ export function buildApiUrl(path, query = {}) {
     return buildUrl(path, query).toString();
 }
 
-export class Util {
-    constructor(app) {
-        this.app = app;
-    }
+export function isValidPath(path) {
+    return Boolean(path && path.length > 0 && !path.includes('..'));
+}
 
-    isValidPath(path) {
-        return path && path.length > 0 && !path.includes('..');
-    }
-    
-    getParentPath(path) {
-        const parts = path.split('/').filter(part => part !== '');
-        if (parts.length <= 1) return '/';
-        parts.pop();
-        return '/' + parts.join('/');
-    }
-    
-    getBaseName(path) {
-        const parts = path.split('/').filter(part => part !== '');
-        return parts.length > 0 ? parts[parts.length - 1] : '';
-    }
+export function getParentPath(path) {
+    const parts = path.split('/').filter(part => part !== '');
+    if (parts.length <= 1) return '/';
+    parts.pop();
+    return '/' + parts.join('/');
+}
 
-    isEditableFile(path) {
-        const ext = path.split('.').pop().toLowerCase();
-        const editableExts = ['txt', 'md', 'json', 'xml', 'html', 'css', 'js', 'py', 'go', 'java', 'c', 'cpp', 'h', 'sh', 'bat', 'yaml', 'yml', 'toml', 'ini', 'conf', 'env'];
-        return editableExts.includes(ext);
-    }
+export function getBaseName(path) {
+    const parts = path.split('/').filter(part => part !== '');
+    return parts.length > 0 ? parts[parts.length - 1] : '';
+}
 
-    normalizePath(path) {
-        return normalizePath(path);
-    }
+export function isEditableFile(path) {
+    const ext = path.split('.').pop().toLowerCase();
+    const editableExts = ['txt', 'md', 'json', 'xml', 'html', 'css', 'js', 'py', 'go', 'java', 'c', 'cpp', 'h', 'sh', 'bat', 'yaml', 'yml', 'toml', 'ini', 'conf', 'env'];
+    return editableExts.includes(ext);
 }

--- a/static/js/util.test.mjs
+++ b/static/js/util.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createUniqueId } from './util.js';
+import { createUniqueId, getBaseName, getParentPath, isEditableFile, isValidPath, normalizePath } from './util.js';
 
 test('uses randomUUID when it is available', () => {
     assert.equal(createUniqueId({ randomUUID: () => 'native-id' }), 'native-id');
@@ -13,4 +13,17 @@ test('creates an RFC 4122 shaped id from getRandomValues', () => {
 
 test('creates distinct ids without Web Crypto', () => {
     assert.notEqual(createUniqueId(null), createUniqueId(null));
+});
+
+test('normalizes and splits virtual paths', () => {
+    assert.equal(normalizePath('/music/./album/../tracks'), '/music/tracks');
+    assert.equal(getParentPath('/music/tracks/song.mp3'), '/music/tracks');
+    assert.equal(getBaseName('/music/tracks/song.mp3'), 'song.mp3');
+});
+
+test('validates paths and editable extensions', () => {
+    assert.equal(isValidPath('/notes/today.md'), true);
+    assert.equal(isValidPath('../outside'), false);
+    assert.equal(isEditableFile('/notes/today.MD'), true);
+    assert.equal(isEditableFile('/video/movie.mp4'), false);
 });


### PR DESCRIPTION
## Summary
- replace the state-free Util class with named pure functions
- remove app.util from the application dependency graph
- import path and file helpers directly in API and search modules
- add coverage for path normalization, splitting, validation, and editable types

## Tests
- node --check for all changed JavaScript modules
- npm test
- npm run build
- go test ./...
- go vet ./...
- git diff --check