### PR TITLE
refactor: split application setup

### DIFF
--- a/static/js/app-initializer.js
+++ b/static/js/app-initializer.js
@@ -1,0 +1,48 @@
+function bindRoutes(app) {
+    app.router.onChange((path, { navigationType = 'initial' } = {}) => {
+        if (path === '/system/uploads') {
+            app.aria2cPageHandler.exitAria2cMode(false);
+            app.uploadPageHandler.enter();
+            return;
+        }
+
+        if (path === '/system/aria2c') {
+            app.uploadPageHandler.exit();
+            if (!app.config.Aria2cEnabled) {
+                app.ui.showToast('Info', 'Aria2c feature is not enabled.', 'info');
+                app.router.navigate('/');
+                return;
+            }
+            if (app.searchHandler.isInSearchMode) app.searchHandler.exitSearchMode(true);
+            app.aria2cPageHandler.enterAria2cMode();
+            return;
+        }
+
+        app.uploadPageHandler.exit();
+        app.aria2cPageHandler.exitAria2cMode(false);
+        void app.navigateToPath(path, { restoreScroll: navigationType === 'pop' });
+    });
+}
+
+export async function initializeApp(app) {
+    app.progressManager.init();
+    app.imageViewer.init();
+    app.searchHandler.init();
+    app.editor.init?.();
+    app.mediaPlayer.init?.();
+
+    app.config = await app.api.getConfig();
+    if (!app.config) throw new Error('Failed to load the application configuration.');
+
+    app.ui.updateAria2cVisibility(app.config.Aria2cEnabled);
+    app.events.bindEvents();
+    app.aria2cPageHandler.init();
+
+    const [specificDirs, storageResult] = await Promise.all([
+        app.api.getSpecificDirs(),
+        app.api.getStorageInfo()
+    ]);
+    app.ui.updateSpecificDirs(specificDirs);
+    app.updateStorageInfo(storageResult);
+    bindRoutes(app);
+}

--- a/static/js/app-services.js
+++ b/static/js/app-services.js
@@ -1,0 +1,32 @@
+import { ApiClient } from './api.js';
+import { Aria2cPageHandler } from './aria2c-page.js';
+import { EventHandler } from './events.js';
+import { FileEditor } from './file-editor.js';
+import { ImageViewer } from './gallery.js';
+import { MediaPlayer } from './media-player.js';
+import { ProgressManager } from './progress.js';
+import { Router } from './router.js';
+import { SearchHandler } from './search.js';
+import { UIManager } from './ui.js';
+import { UploadPageHandler } from './upload-page.js';
+import { Uploader } from './uploader.js';
+
+export function createAppServices(app) {
+    const attach = (name, service) => {
+        app[name] = service;
+        return service;
+    };
+
+    attach('router', new Router(app.store));
+    attach('api', new ApiClient(app));
+    attach('uploader', new Uploader(app));
+    attach('events', new EventHandler(app));
+    attach('ui', new UIManager(app));
+    attach('progressManager', new ProgressManager());
+    attach('editor', new FileEditor(app));
+    attach('mediaPlayer', new MediaPlayer(app));
+    attach('imageViewer', new ImageViewer(app));
+    attach('searchHandler', new SearchHandler(app));
+    attach('aria2cPageHandler', new Aria2cPageHandler(app));
+    attach('uploadPageHandler', new UploadPageHandler(app));
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,18 +1,9 @@
-import { Router } from './router.js';
-import { ProgressManager } from './progress.js';
-import { FileEditor } from './file-editor.js';
-import { MediaPlayer } from './media-player.js';
-import { ImageViewer } from './gallery.js';
-import { SearchHandler } from './search.js';
-import { UIManager } from './ui.js';
-import { ApiClient } from './api.js';
-import { EventHandler } from './events.js';
-import { Uploader } from './uploader.js';
-import { Aria2cPageHandler } from './aria2c-page.js';
-import { UploadPageHandler } from './upload-page.js';
 import { loadTemplates } from './template.js';
 import { AppStateStore } from './state.js';
 import { ALL_TEMPLATES } from './template-registry.js';
+import { createAppServices } from './app-services.js';
+import { initializeApp } from './app-initializer.js';
+import { getParentPath, isEditableFile } from './util.js';
 
 class FileManagerApp {
     constructor() {
@@ -22,21 +13,7 @@ class FileManagerApp {
         this.isPC = !/Mobi|Android/i.test(navigator.userAgent);
         this.eventBus = new EventTarget();
 
-        // Initialize modules that don't depend on templates in their constructor
-        this.router = new Router(this.store);
-        this.api = new ApiClient(this);
-        this.uploader = new Uploader(this);
-        this.events = new EventHandler(this);
-        this.ui = new UIManager(this);
-        
-        // These will be initialized properly in the init method
-        this.progressManager = new ProgressManager();
-        this.editor = new FileEditor(this);
-        this.mediaPlayer = new MediaPlayer(this);
-        this.imageViewer = new ImageViewer(this);
-        this.searchHandler = new SearchHandler(this);
-        this.aria2cPageHandler = new Aria2cPageHandler(this);
-        this.uploadPageHandler = new UploadPageHandler(this);
+        createAppServices(this);
     }
 
     emit(type, detail = {}, { cancelable = false } = {}) {
@@ -49,60 +26,7 @@ class FileManagerApp {
     get selectionAnchorPath() { return this.store.getState().selection.anchorPath; }
 
     async init() {
-        // Initialize modules that need templates
-        this.progressManager.init();
-        this.imageViewer.init();
-        this.searchHandler.init();
-        
-        // These might not have been converted to templates, but it's good practice
-        // to have an init method for consistency. Let's assume they have one.
-        // We need to check their implementation and add init() if it's missing.
-        if(typeof this.editor.init === 'function') this.editor.init();
-        if(typeof this.mediaPlayer.init === 'function') this.mediaPlayer.init();
-
-
-        // Fetch config first
-        this.config = await this.api.getConfig();
-        if (!this.config) {
-            throw new Error('Failed to load the application configuration.');
-        }
-
-        // Update UI based on config
-        this.ui.updateAria2cVisibility(this.config.Aria2cEnabled);
-
-        this.events.bindEvents();
-        this.aria2cPageHandler.init();
-
-        const [specificDirs, storageResult] = await Promise.all([
-            this.api.getSpecificDirs(),
-            this.api.getStorageInfo()
-        ]);
-
-        this.ui.updateSpecificDirs(specificDirs);
-        this.updateStorageInfo(storageResult);
-
-        // Setup router
-        this.router.onChange((path, { navigationType = 'initial' } = {}) => {
-            if (path === '/system/uploads') {
-                this.aria2cPageHandler.exitAria2cMode(false);
-                this.uploadPageHandler.enter();
-            } else if (path === '/system/aria2c') {
-                this.uploadPageHandler.exit();
-                if (!this.config.Aria2cEnabled) {
-                    this.ui.showToast('Info', 'Aria2c feature is not enabled.', 'info');
-                    this.router.navigate('/');
-                    return;
-                }
-                if (this.searchHandler.isInSearchMode) {
-                    this.searchHandler.exitSearchMode(true);
-                }
-                this.aria2cPageHandler.enterAria2cMode();
-            } else {
-                this.uploadPageHandler.exit();
-                this.aria2cPageHandler.exitAria2cMode(false);
-                this.navigateToPath(path, { restoreScroll: navigationType === 'pop' });
-            }
-        });
+        await initializeApp(this);
     }
 
     async loadFiles(path, options = {}) {
@@ -132,7 +56,7 @@ class FileManagerApp {
     navigateToParent() {
         const currentPath = this.router.getCurrentPath();
         if (currentPath === '/') return;
-        const parentPath = this.util.getParentPath(currentPath);
+        const parentPath = getParentPath(currentPath);
         this.router.navigate(parentPath);
     }
 
@@ -161,7 +85,7 @@ class FileManagerApp {
             this.mediaPlayer.playAudio(path);
         } else if (mimeType && mimeType.startsWith('video/')) {
             this.mediaPlayer.playVideo(path);
-        } else if (this.util.isEditableFile(path)) {
+        } else if (isEditableFile(path)) {
             this.editFile(path);
         } else {
             this.api.downloadFile(path);


### PR DESCRIPTION
## Summary
- move service construction out of FileManagerApp into app-services
- move component startup, config loading, and route wiring into app-initializer
- reduce FileManagerApp to application behavior and state coordination
- replace the remaining removed util service references with pure functions

## Tests
- node --check static/js/app.js
- node --check static/js/app-services.js
- node --check static/js/app-initializer.js
- npm test
- npm run build
- TMPDIR=/var/tmp go test ./...
- TMPDIR=/var/tmp go vet ./...
- git diff --check