### PR TITLE
fix: render complete directory pages

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -3,6 +3,12 @@ import { buildApiUrl } from './util.js';
 import { ImageLoader } from './image-loader.js';
 import { TEMPLATES } from './template-registry.js';
 
+export const VIRTUAL_RENDER_THRESHOLD = 500;
+
+export function shouldUseVirtualRendering(itemCount) {
+    return itemCount > VIRTUAL_RENDER_THRESHOLD;
+}
+
 export class UIManager {
     constructor(app) {
         this.app = app;
@@ -323,7 +329,7 @@ export class UIManager {
     }
 
     renderGridView(files, container) {
-        if (files.length > 80) {
+        if (shouldUseVirtualRendering(files.length)) {
             this.renderVirtualGrid(files, container);
             return;
         }
@@ -356,7 +362,7 @@ export class UIManager {
     }
 
     renderListView(files, container) {
-        if (files.length > 80) {
+        if (shouldUseVirtualRendering(files.length)) {
             this.renderVirtualList(files, container);
             return;
         }

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { VIRTUAL_RENDER_THRESHOLD, shouldUseVirtualRendering } from './ui.js';
+
+test('renders a complete API directory page without virtualization', () => {
+    assert.equal(shouldUseVirtualRendering(111), false);
+    assert.equal(shouldUseVirtualRendering(200), false);
+});
+
+test('keeps virtualization for unusually large client-side result sets', () => {
+    assert.equal(shouldUseVirtualRendering(VIRTUAL_RENDER_THRESHOLD + 1), true);
+});


### PR DESCRIPTION
## Summary
- render normal server-paginated directory pages as complete grids and lists
- avoid switching a 111-item directory to the fragile virtual viewport
- retain virtualization for client-side result sets above 500 items
- add regression coverage for 111- and 200-item pages

## Tests
- node --check static/js/ui.js
- npm test
- npm run build
- TMPDIR=/var/tmp go test ./...
- TMPDIR=/var/tmp go vet ./...
- git diff --check