### PR TITLE
refactor: render loading state from store

### DIFF
--- a/static/js/app-initializer.js
+++ b/static/js/app-initializer.js
@@ -25,6 +25,7 @@ function bindRoutes(app) {
 }
 
 export async function initializeApp(app) {
+    app.ui.bindStore();
     app.progressManager.init();
     app.imageViewer.init();
     app.searchHandler.init();

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -24,6 +24,7 @@ export class UIManager {
         this.directoryPageNumber = 0;
         this.removeVirtualScroll = null;
         this.nameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+        this.unsubscribeStore = null;
     }
 
     get currentFiles() { return this.app.store.getState().directory.files; }
@@ -748,17 +749,26 @@ export class UIManager {
     showLoading() {
         const pendingOperations = this.app.store.getState().ui.pendingOperations + 1;
         this.app.store.update('ui', { pendingOperations }, 'OPERATION_STARTED');
-        const overlay = document.getElementById('loading-overlay');
-        if (overlay) overlay.style.display = 'flex';
     }
 
     hideLoading() {
         const pendingOperations = Math.max(0, this.app.store.getState().ui.pendingOperations - 1);
         this.app.store.update('ui', { pendingOperations }, 'OPERATION_FINISHED');
-        if (pendingOperations === 0) {
+    }
+
+    bindStore() {
+        this.unsubscribeStore?.();
+        const renderLoading = state => {
             const overlay = document.getElementById('loading-overlay');
-            if (overlay) overlay.style.display = 'none';
-        }
+            if (!overlay) return;
+            const loading = state.ui.pendingOperations > 0;
+            overlay.style.display = loading ? 'flex' : 'none';
+            overlay.setAttribute('aria-hidden', String(!loading));
+        };
+        renderLoading(this.app.store.getState());
+        this.unsubscribeStore = this.app.store.subscribe((state, previous) => {
+            if (state.ui.pendingOperations !== previous.ui.pendingOperations) renderLoading(state);
+        });
     }
 
     updateSpecificDirs(dirs) {

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { VIRTUAL_RENDER_THRESHOLD, shouldUseVirtualRendering } from './ui.js';
+import { UIManager } from './ui.js';
+import { AppStateStore } from './state.js';
 
 test('renders a complete API directory page without virtualization', () => {
     assert.equal(shouldUseVirtualRendering(111), false);
@@ -9,4 +11,28 @@ test('renders a complete API directory page without virtualization', () => {
 
 test('keeps virtualization for unusually large client-side result sets', () => {
     assert.equal(shouldUseVirtualRendering(VIRTUAL_RENDER_THRESHOLD + 1), true);
+});
+
+test('derives loading overlay visibility from store updates', t => {
+    const overlay = {
+        style: {},
+        attributes: new Map(),
+        setAttribute(name, value) { this.attributes.set(name, value); }
+    };
+    globalThis.document = { getElementById: id => id === 'loading-overlay' ? overlay : null };
+    globalThis.matchMedia = () => ({ matches: false });
+    t.after(() => {
+        delete globalThis.document;
+        delete globalThis.matchMedia;
+    });
+    const app = { store: new AppStateStore() };
+    const ui = new UIManager(app);
+    ui.bindStore();
+
+    ui.showLoading();
+    assert.equal(overlay.style.display, 'flex');
+    assert.equal(overlay.attributes.get('aria-hidden'), 'false');
+    ui.hideLoading();
+    assert.equal(overlay.style.display, 'none');
+    assert.equal(overlay.attributes.get('aria-hidden'), 'true');
 });

--- a/static/templates/app_shell.html
+++ b/static/templates/app_shell.html
@@ -22,7 +22,7 @@
     </div>
 </div>
 <div id="toast-container"></div>
-<div id="loading-overlay" style="display: none;"><div class="loading-spinner"></div></div>
+<div id="loading-overlay" style="display: none;" aria-hidden="true"><div class="loading-spinner"></div></div>
 <div id="aria2c-status-modal" class="modal" style="display: none;">
     <div class="modal-content">
         <div class="modal-header"><h2>Aria2c Downloads</h2><span class="close-button">&times;</span></div>


### PR DESCRIPTION
## Summary
- subscribe the UI layer to application store updates during initialization
- derive loading overlay visibility and accessibility state from pending operations
- keep showLoading and hideLoading as state actions without direct DOM writes
- add coverage for the store-driven loading lifecycle

## Tests
- node --check static/js/ui.js
- node --check static/js/app-initializer.js
- npm test
- npm run build
- TMPDIR=/var/tmp go test ./...
- TMPDIR=/var/tmp go vet ./...
- git diff --check