### PR TITLE
fix: consume prepared ZIP downloads once

### DIFF
--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -940,15 +940,16 @@ func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) DownloadPreparedZip(w http.ResponseWriter, r *http.Request) {
 	token := mux.Vars(r)["token"]
-	value, ok := h.zipDownloads.Load(token)
+	// A prepared archive is a one-time capability. Consume the token before
+	// opening the file so concurrent requests cannot replay the same archive.
+	value, ok := h.zipDownloads.LoadAndDelete(token)
 	if !ok {
 		h.respondError(w, "Download not found or expired", http.StatusNotFound)
 		return
 	}
 	prepared := value.(preparedZip)
+	defer func() { _ = os.Remove(prepared.path) }()
 	if time.Now().After(prepared.expiresAt) {
-		h.zipDownloads.Delete(token)
-		_ = os.Remove(prepared.path)
 		h.respondError(w, "Download expired", http.StatusGone)
 		return
 	}

--- a/handlers/zip_download_test.go
+++ b/handlers/zip_download_test.go
@@ -31,6 +31,12 @@ func TestDownloadPreparedZipServesStoredArchive(t *testing.T) {
 	if got := res.Header().Get("Content-Disposition"); got != "attachment; filename=\"files.zip\"" {
 		t.Fatalf("Content-Disposition = %q", got)
 	}
+	if _, ok := h.zipDownloads.Load("token"); ok {
+		t.Fatal("prepared ZIP token was not consumed")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("prepared ZIP was not removed, stat error = %v", err)
+	}
 }
 
 func TestDownloadPreparedZipRejectsExpiredToken(t *testing.T) {
@@ -46,5 +52,31 @@ func TestDownloadPreparedZipRejectsExpiredToken(t *testing.T) {
 	h.DownloadPreparedZip(res, req)
 	if res.Code != http.StatusGone {
 		t.Fatalf("status = %d, want %d", res.Code, http.StatusGone)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expired ZIP was not removed, stat error = %v", err)
+	}
+}
+
+func TestDownloadPreparedZipIsSingleUse(t *testing.T) {
+	h := NewHandler(&types.Config{StorageDir: t.TempDir()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	path := t.TempDir() + "/prepared.zip"
+	if err := os.WriteFile(path, []byte("prepared archive"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	h.zipDownloads.Store("once", preparedZip{path: path, expiresAt: time.Now().Add(time.Minute)})
+
+	first := httptest.NewRecorder()
+	firstReq := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/files/download-zip/once", nil), map[string]string{"token": "once"})
+	h.DownloadPreparedZip(first, firstReq)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d", first.Code, http.StatusOK)
+	}
+
+	second := httptest.NewRecorder()
+	secondReq := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/files/download-zip/once", nil), map[string]string{"token": "once"})
+	h.DownloadPreparedZip(second, secondReq)
+	if second.Code != http.StatusNotFound {
+		t.Fatalf("second status = %d, want %d", second.Code, http.StatusNotFound)
 	}
 }


### PR DESCRIPTION
## Summary
- consume prepared ZIP tokens atomically before serving
- remove prepared ZIP files after serving or expiry
- add regression coverage for deletion and single-use behavior

## Validation
- `go test ./...`
- `go test -race ./handlers`
- `git diff --check`

This prevents repeated downloads and bounds the lifetime of prepared ZIP files in `/tmp`.