### PR TITLE
security: bound API request bodies

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Handler:           responseCompressionMiddleware(r),
+		Handler:           requestBodyLimitMiddleware(responseCompressionMiddleware(r)),
 		Addr:              fmt.Sprintf(":%d", cfg.Port),
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,

--- a/request_limits.go
+++ b/request_limits.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	maxJSONBodyBytes = 1 << 20
+	maxSaveBodyBytes = 11 << 20
+)
+
+// requestBodyLimitMiddleware bounds API request bodies before they reach JSON
+// decoders. Large binary upload endpoints retain their own streaming limits.
+func requestBodyLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil && strings.HasPrefix(r.URL.Path, "/api/") &&
+			r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions &&
+			r.URL.Path != "/api/files/upload" && !strings.HasSuffix(r.URL.Path, "/chunks") {
+			limit := int64(maxJSONBodyBytes)
+			if r.URL.Path == "/api/files/save" {
+				limit = maxSaveBodyBytes
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, limit)
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/request_limits_test.go
+++ b/request_limits_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestBodyLimitMiddlewareRejectsOversizedJSON(t *testing.T) {
+	handler := requestBodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/files/delete", bytes.NewReader(bytes.Repeat([]byte("x"), maxJSONBodyBytes+1)))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestRequestBodyLimitMiddlewarePreservesStreamingEndpoints(t *testing.T) {
+	handler := requestBodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	body := bytes.Repeat([]byte("x"), maxJSONBodyBytes+1)
+	for _, path := range []string{"/api/files/upload", "/api/files/upload-sessions/id/chunks"} {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+		if res.Code != http.StatusNoContent {
+			t.Fatalf("path %s: status = %d, want %d", path, res.Code, http.StatusNoContent)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a common request-body limit for API mutation endpoints
- preserve the existing large multipart upload and resumable chunk streaming paths
- preserve the editor's existing 11 MiB save limit
- add middleware regression tests

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`

This prevents oversized JSON requests from being fully materialized by endpoint decoders.