### PR TITLE
security: bound API input shapes

### DIFF
--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -64,6 +64,10 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Path required", http.StatusBadRequest)
 		return
 	}
+	if len(path) > maxVirtualPathBytes {
+		h.respondError(w, "Path is too long", http.StatusBadRequest)
+		return
+	}
 
 	fullPath, err := h.convertToPhysicalPath(path)
 	if err != nil {
@@ -887,9 +891,8 @@ func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-
-	if len(req.Paths) == 0 {
-		h.respondError(w, "No paths provided", http.StatusBadRequest)
+	if err := validateBatchPaths(req.Paths); err != nil {
+		h.respondError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -1205,6 +1208,10 @@ func (h *Handler) DeleteMultipleFiles(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+	if err := validateBatchPaths(req.Paths); err != nil {
+		h.respondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// 並列処理で削除
 	var errors []string
@@ -1263,6 +1270,10 @@ func (h *Handler) CreateDirectory(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+	if len(req.Path) > maxVirtualPathBytes || len(req.Name) > maxRelativePathBytes {
+		h.respondError(w, "Path or name is too long", http.StatusBadRequest)
+		return
+	}
 
 	parentPath, err := h.convertToPhysicalPath(req.Path)
 	if err != nil {
@@ -1315,6 +1326,10 @@ func (h *Handler) MoveFile(w http.ResponseWriter, r *http.Request) {
 
 	if req.SourcePath == "" || req.TargetPath == "" {
 		h.respondError(w, "Source and target paths required", http.StatusBadRequest)
+		return
+	}
+	if len(req.SourcePath) > maxVirtualPathBytes || len(req.TargetPath) > maxVirtualPathBytes {
+		h.respondError(w, "Path is too long", http.StatusBadRequest)
 		return
 	}
 
@@ -1384,6 +1399,10 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 
 	if req.Path == "" || req.Name == "" {
 		h.respondError(w, "Path and name required", http.StatusBadRequest)
+		return
+	}
+	if len(req.Path) > maxVirtualPathBytes || len(req.Name) > maxRelativePathBytes {
+		h.respondError(w, "Path or name is too long", http.StatusBadRequest)
 		return
 	}
 

--- a/handlers/input_limits.go
+++ b/handlers/input_limits.go
@@ -1,0 +1,27 @@
+package handlers
+
+import "fmt"
+
+const (
+	maxVirtualPathBytes  = 4096
+	maxRelativePathBytes = 4096
+	maxBatchPaths        = 1000
+	maxSearchTermBytes   = 1024
+	maxAria2URLBytes     = 8192
+	maxAria2GIDBytes     = 128
+)
+
+func validateBatchPaths(paths []string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("at least one path is required")
+	}
+	if len(paths) > maxBatchPaths {
+		return fmt.Errorf("too many paths")
+	}
+	for _, path := range paths {
+		if len(path) > maxVirtualPathBytes {
+			return fmt.Errorf("path is too long")
+		}
+	}
+	return nil
+}

--- a/handlers/resumable_upload_handlers.go
+++ b/handlers/resumable_upload_handlers.go
@@ -131,7 +131,7 @@ func (h *Handler) CreateUpload(w http.ResponseWriter, r *http.Request) {
 	if req.Path == "" {
 		req.Path = "/"
 	}
-	if req.Size < 0 || req.Size > h.config.MaxFileSize<<20 || req.RelativePath == "" {
+	if req.Size < 0 || req.Size > h.config.MaxFileSize<<20 || req.RelativePath == "" || len(req.Path) > maxVirtualPathBytes || len(req.RelativePath) > maxRelativePathBytes {
 		h.respondError(w, "Invalid upload size or path", http.StatusBadRequest)
 		return
 	}

--- a/handlers/resumable_upload_handlers_test.go
+++ b/handlers/resumable_upload_handlers_test.go
@@ -133,3 +133,15 @@ func TestMediaTypeByPathHasContainerIndependentVideoFallbacks(t *testing.T) {
 		}
 	}
 }
+
+func TestInputLimitsRejectOversizedPathAndBatch(t *testing.T) {
+	if _, err := secureJoin(t.TempDir(), strings.Repeat("a", maxRelativePathBytes+1)); err == nil {
+		t.Fatal("oversized relative path was accepted")
+	}
+	if err := validateBatchPaths(make([]string, maxBatchPaths+1)); err == nil {
+		t.Fatal("oversized batch was accepted")
+	}
+	if err := validateBatchPaths([]string{strings.Repeat("a", maxVirtualPathBytes+1)}); err == nil {
+		t.Fatal("oversized path in batch was accepted")
+	}
+}

--- a/handlers/search_handlers.go
+++ b/handlers/search_handlers.go
@@ -44,6 +44,14 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Search term required", http.StatusBadRequest)
 		return
 	}
+	if len(req.Term) > maxSearchTermBytes || len(req.Cursor) > maxVirtualPathBytes {
+		h.respondError(w, "Search term or cursor is too long", http.StatusBadRequest)
+		return
+	}
+	if req.Scope != "" && req.Scope != "current" && req.Scope != "recursive" {
+		h.respondError(w, "Invalid search scope", http.StatusBadRequest)
+		return
+	}
 
 	if req.Limit <= 0 || req.Limit > 500 {
 		req.Limit = 100

--- a/handlers/system_handlers.go
+++ b/handlers/system_handlers.go
@@ -183,6 +183,10 @@ func (h *Handler) DownloadWithAria2c(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "URL and path are required", http.StatusBadRequest)
 		return
 	}
+	if len(req.URL) > maxAria2URLBytes || len(req.Path) > maxVirtualPathBytes {
+		h.respondError(w, "URL or path is too long", http.StatusBadRequest)
+		return
+	}
 
 	safePath, err := h.buildSafePath(req.Path)
 	if err != nil {
@@ -283,6 +287,10 @@ func (h *Handler) ControlAria2cDownload(w http.ResponseWriter, r *http.Request) 
 
 	if req.GID == "" || req.Action == "" {
 		h.respondError(w, "GID and action are required", http.StatusBadRequest)
+		return
+	}
+	if len(req.GID) > maxAria2GIDBytes {
+		h.respondError(w, "GID is too long", http.StatusBadRequest)
 		return
 	}
 

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -69,6 +69,9 @@ func (h *Handler) convertToVirtualPath(physicalPath string) string {
 
 // 仮想パスを物理パスに変換するメソッド
 func (h *Handler) convertToPhysicalPath(virtualPath string) (string, error) {
+	if len(virtualPath) > maxVirtualPathBytes {
+		return "", fmt.Errorf("path is too long")
+	}
 	var physicalPath string
 
 	if virtualPath == "" || virtualPath == "/" {
@@ -288,6 +291,9 @@ func (h *Handler) isProtectedRoot(path string) bool {
 }
 
 func secureJoin(basePath, relPath string) (string, error) {
+	if len(relPath) > maxRelativePathBytes {
+		return "", fmt.Errorf("relative path is too long")
+	}
 	absBasePath, err := filepath.Abs(basePath)
 	if err != nil {
 		return "", fmt.Errorf("could not get absolute base path: %w", err)


### PR DESCRIPTION
## Summary
- cap batch path count and path lengths
- cap virtual and relative paths across file and upload operations
- cap search terms, cursors, aria2 URLs, and GIDs
- reject unsupported search scopes
- add regression tests for oversized input shapes

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`

This prevents oversized collections and strings from driving disproportionate memory, regex, filesystem, or RPC work.