### PR TITLE
security: limit expensive concurrent work

### DIFF
--- a/handlers/concurrency.go
+++ b/handlers/concurrency.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+)
+
+func tryAcquire(gate chan struct{}) bool {
+	select {
+	case gate <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func release(gate chan struct{}) {
+	<-gate
+}
+
+func respondBusy(w http.ResponseWriter) {
+	w.Header().Set("Retry-After", "5")
+	w.WriteHeader(http.StatusTooManyRequests)
+}
+
+func contextStillActive(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+		return true
+	}
+}

--- a/handlers/concurrency_test.go
+++ b/handlers/concurrency_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTryAcquireIsBoundedAndReleases(t *testing.T) {
+	gate := make(chan struct{}, 1)
+	if !tryAcquire(gate) {
+		t.Fatal("first acquire failed")
+	}
+	if tryAcquire(gate) {
+		t.Fatal("second acquire exceeded gate capacity")
+	}
+	release(gate)
+	if !tryAcquire(gate) {
+		t.Fatal("acquire after release failed")
+	}
+}
+
+func TestRespondBusyIsRetryable(t *testing.T) {
+	res := httptest.NewRecorder()
+	respondBusy(res)
+	if res.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusTooManyRequests)
+	}
+	if got := res.Header().Get("Retry-After"); got != "5" {
+		t.Fatalf("Retry-After = %q, want 5", got)
+	}
+}

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -75,6 +75,11 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Cannot upload directly to a protected root", http.StatusBadRequest)
 		return
 	}
+	if !tryAcquire(h.thumbnailGate) {
+		respondBusy(w)
+		return
+	}
+	defer release(h.thumbnailGate)
 	info, err := os.Stat(fullPath)
 	if err != nil || info.IsDir() {
 		h.respondError(w, "Cannot inspect video", http.StatusBadRequest)
@@ -160,6 +165,11 @@ func (h *Handler) ExtractFile(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Cannot inspect extraction destination", http.StatusInternalServerError)
 		return
 	}
+	if !tryAcquire(h.extractGate) {
+		respondBusy(w)
+		return
+	}
+	defer release(h.extractGate)
 
 	// 並列処理で解凍
 	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
@@ -893,6 +903,11 @@ func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if !tryAcquire(h.zipGate) {
+		respondBusy(w)
+		return
+	}
+	defer release(h.zipGate)
 
 	tmp, err := os.CreateTemp("", "puremania-download-*.zip")
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -17,13 +17,17 @@ const (
 
 // Handler はAPIハンドラーの依存関係を保持
 type Handler struct {
-	config       *types.Config
-	cache        *types.TTLCache
-	workerPool   *types.WorkerPool
-	logger       *slog.Logger
-	uploadLocks  [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
-	uploadGate   chan struct{}   // bounds concurrent disk writes across sessions
-	zipDownloads sync.Map        // token -> preparedZip; entries expire after download preparation
+	config        *types.Config
+	cache         *types.TTLCache
+	workerPool    *types.WorkerPool
+	logger        *slog.Logger
+	uploadLocks   [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
+	uploadGate    chan struct{}   // bounds concurrent disk writes across sessions
+	zipGate       chan struct{}   // bounds concurrent archive preparation
+	extractGate   chan struct{}   // bounds concurrent archive extraction
+	thumbnailGate chan struct{}   // bounds concurrent ffmpeg work
+	searchGate    chan struct{}   // bounds concurrent recursive searches
+	zipDownloads  sync.Map        // token -> preparedZip; entries expire after download preparation
 }
 
 type preparedZip struct {
@@ -49,11 +53,15 @@ func NewHandler(config *types.Config, logger *slog.Logger) *Handler {
 		writeSlots = 32
 	}
 	h := &Handler{
-		config:     config,
-		cache:      cache.NewTTLCache(250*1024*1024, 15000), // 250MB, 15K items
-		workerPool: worker.NewWorkerPool(),
-		logger:     logger,
-		uploadGate: make(chan struct{}, writeSlots),
+		config:        config,
+		cache:         cache.NewTTLCache(250*1024*1024, 15000), // 250MB, 15K items
+		workerPool:    worker.NewWorkerPool(),
+		logger:        logger,
+		uploadGate:    make(chan struct{}, writeSlots),
+		zipGate:       make(chan struct{}, 2),
+		extractGate:   make(chan struct{}, 2),
+		thumbnailGate: make(chan struct{}, 2),
+		searchGate:    make(chan struct{}, 4),
 	}
 	h.cleanupExpiredUploadSessions()
 	return h

--- a/handlers/search_handlers.go
+++ b/handlers/search_handlers.go
@@ -73,6 +73,14 @@ func (h *Handler) SearchFiles(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, "Invalid path", http.StatusBadRequest)
 		return
 	}
+	if !contextStillActive(r.Context()) {
+		return
+	}
+	if !tryAcquire(h.searchGate) {
+		respondBusy(w)
+		return
+	}
+	defer release(h.searchGate)
 
 	results, searchErr := h.performSearchPage(r.Context(), req, basePath)
 	if searchErr == nil {


### PR DESCRIPTION
## Summary
- cap concurrent ZIP preparation, archive extraction, ffmpeg thumbnail generation, and searches
- return `429` with `Retry-After` when an expensive-work gate is full
- add semaphore regression coverage

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`

This prevents concurrent expensive requests from exhausting CPU, memory, worker capacity, or disk I/O.