### PR TITLE
fix: correct cache size accounting

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -72,8 +72,7 @@ func Set(c *types.TTLCache, key string, data interface{}, size int64, ttl time.D
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 
-	if existing, exists := c.Entries[key]; exists {
-		c.CurSize -= existing.Size
+	if _, exists := c.Entries[key]; exists {
 		evict(c, key)
 	}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,28 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetReplacementKeepsSizeAccounting(t *testing.T) {
+	c := NewTTLCache(10, 10)
+
+	Set(c, "key", "first", 6, time.Hour)
+	Set(c, "key", "second", 6, time.Hour)
+
+	entries, size := Stats(c)
+	if entries != 1 || size != 6 {
+		t.Fatalf("after replacement: entries=%d size=%d, want entries=1 size=6", entries, size)
+	}
+
+	Set(c, "other", "third", 5, time.Hour)
+
+	entries, size = Stats(c)
+	if entries != 1 || size != 5 {
+		t.Fatalf("after size-based eviction: entries=%d size=%d, want entries=1 size=5", entries, size)
+	}
+	if _, ok := Get(c, "key"); ok {
+		t.Fatal("expected the replaced key to be evicted when the cache limit is exceeded")
+	}
+}


### PR DESCRIPTION
## Summary
- remove the duplicate cache-size subtraction when replacing an entry
- add a regression test covering replacement and size-based eviction

## Validation
- `go test ./...`
- `go test -race ./cache`
- `git diff --check`