### PR TITLE
fix: safely encode download filenames

### DIFF
--- a/handlers/content_disposition_test.go
+++ b/handlers/content_disposition_test.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContentDispositionEncodesFilename(t *testing.T) {
+	got := contentDisposition(`report"final.txt`)
+
+	if strings.ContainsAny(got, "\r\n") {
+		t.Fatalf("Content-Disposition contains a line break: %q", got)
+	}
+	if !strings.HasPrefix(got, "inline; filename=") {
+		t.Fatalf("Content-Disposition = %q, want inline filename parameter", got)
+	}
+	if strings.Contains(got, `filename="report"final.txt"`) {
+		t.Fatalf("filename quote was not encoded: %q", got)
+	}
+}
+
+func TestContentDispositionEscapesControlCharacters(t *testing.T) {
+	got := contentDisposition("report\x00.txt")
+	if strings.ContainsAny(got, "\x00\r\n") {
+		t.Fatalf("Content-Disposition contains a raw control character: %q", got)
+	}
+	if !strings.Contains(got, "filename*=utf-8''report%00.txt") {
+		t.Fatalf("Content-Disposition = %q, want RFC 5987 encoded filename", got)
+	}
+}

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"os/exec"
@@ -805,10 +806,17 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 
 	filename := filepath.Base(path)
 	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filename))
+	w.Header().Set("Content-Disposition", contentDisposition(filename))
 
 	// http.ServeContentを使用してsendfile最適化とRange/If-Modified-Since自動処理
 	http.ServeContent(w, r, filename, stat.ModTime(), file)
+}
+
+func contentDisposition(filename string) string {
+	if formatted := mime.FormatMediaType("inline", map[string]string{"filename": filename}); formatted != "" {
+		return formatted
+	}
+	return `inline; filename="download"`
 }
 
 // GetFileContent - 画像はhttp.ServeFileで最適化、テキストはキャッシュ使用


### PR DESCRIPTION
## Summary
- format download filenames with the standard MIME media-type encoder
- prevent quotes and control characters from creating malformed response headers
- add regression tests for quoted and control-character filenames

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`