### PR TITLE
fix: bound thumbnail cache growth

### DIFF
--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -31,8 +31,78 @@ import (
 )
 
 const (
-	thumbnailDir = ".cache/thumbnails"
+	thumbnailDir                   = ".cache/thumbnails"
+	thumbnailMaxBytes        int64 = 256 << 20
+	thumbnailMaxFiles              = 4096
+	thumbnailCleanupInterval       = 5 * time.Minute
+	thumbnailTempTTL               = 10 * time.Minute
 )
+
+type thumbnailCacheEntry struct {
+	path    string
+	size    int64
+	modTime time.Time
+}
+
+func cleanupThumbnailCache(dir string, maxBytes int64, maxFiles int) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	cacheEntries := make([]thumbnailCacheEntry, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".thumbnail-") {
+			if now.Sub(info.ModTime()) >= thumbnailTempTTL {
+				_ = os.Remove(filepath.Join(dir, entry.Name()))
+			}
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".jpg") || !info.Mode().IsRegular() {
+			continue
+		}
+		cacheEntries = append(cacheEntries, thumbnailCacheEntry{
+			path:    filepath.Join(dir, entry.Name()),
+			size:    info.Size(),
+			modTime: info.ModTime(),
+		})
+	}
+
+	sort.Slice(cacheEntries, func(i, j int) bool {
+		return cacheEntries[i].modTime.Before(cacheEntries[j].modTime)
+	})
+
+	var totalBytes int64
+	for _, entry := range cacheEntries {
+		totalBytes += entry.size
+	}
+	for len(cacheEntries) > 0 && (totalBytes > maxBytes || len(cacheEntries) > maxFiles) {
+		oldest := cacheEntries[0]
+		cacheEntries = cacheEntries[1:]
+		if err := os.Remove(oldest.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		totalBytes -= oldest.size
+	}
+	return nil
+}
+
+func (h *Handler) cleanupThumbnailCacheIfDue(dir string, force bool) error {
+	h.thumbnailCleanupMu.Lock()
+	defer h.thumbnailCleanupMu.Unlock()
+
+	now := time.Now()
+	if !force && now.Sub(h.lastThumbnailCleanup) < thumbnailCleanupInterval {
+		return nil
+	}
+	h.lastThumbnailCleanup = now
+	return cleanupThumbnailCache(dir, thumbnailMaxBytes, thumbnailMaxFiles)
+}
 
 func (h *Handler) generateThumbnail(ctx context.Context, videoPath, thumbnailPath string) error {
 	// ffmpeg command to generate thumbnail
@@ -54,6 +124,9 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("Failed to create thumbnail directory", "path", thumbnailDir, "error", err)
 		h.respondError(w, "Cannot create thumbnail directory", http.StatusInternalServerError)
 		return
+	}
+	if err := h.cleanupThumbnailCacheIfDue(thumbnailDir, false); err != nil {
+		h.logger.Warn("Failed to clean thumbnail cache", "path", thumbnailDir, "error", err)
 	}
 
 	path := r.URL.Query().Get("path")
@@ -114,7 +187,13 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		if err := h.generateThumbnail(ctx, fullPath, tmpPath); err != nil {
 			return err
 		}
-		return os.Rename(tmpPath, thumbnailPath)
+		if err := os.Rename(tmpPath, thumbnailPath); err != nil {
+			return err
+		}
+		if err := h.cleanupThumbnailCacheIfDue(thumbnailDir, true); err != nil {
+			h.logger.Warn("Failed to enforce thumbnail cache limit", "path", thumbnailDir, "error", err)
+		}
+		return nil
 	})
 
 	result := <-resultChan

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -17,17 +17,19 @@ const (
 
 // Handler はAPIハンドラーの依存関係を保持
 type Handler struct {
-	config        *types.Config
-	cache         *types.TTLCache
-	workerPool    *types.WorkerPool
-	logger        *slog.Logger
-	uploadLocks   [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
-	uploadGate    chan struct{}   // bounds concurrent disk writes across sessions
-	zipGate       chan struct{}   // bounds concurrent archive preparation
-	extractGate   chan struct{}   // bounds concurrent archive extraction
-	thumbnailGate chan struct{}   // bounds concurrent ffmpeg work
-	searchGate    chan struct{}   // bounds concurrent recursive searches
-	zipDownloads  sync.Map        // token -> preparedZip; entries expire after download preparation
+	config               *types.Config
+	cache                *types.TTLCache
+	workerPool           *types.WorkerPool
+	logger               *slog.Logger
+	uploadLocks          [256]sync.Mutex // fixed striped locks; serializes writes to one session without unbounded state
+	uploadGate           chan struct{}   // bounds concurrent disk writes across sessions
+	zipGate              chan struct{}   // bounds concurrent archive preparation
+	extractGate          chan struct{}   // bounds concurrent archive extraction
+	thumbnailGate        chan struct{}   // bounds concurrent ffmpeg work
+	searchGate           chan struct{}   // bounds concurrent recursive searches
+	zipDownloads         sync.Map        // token -> preparedZip; entries expire after download preparation
+	thumbnailCleanupMu   sync.Mutex
+	lastThumbnailCleanup time.Time
 }
 
 type preparedZip struct {

--- a/handlers/thumbnail_cache_test.go
+++ b/handlers/thumbnail_cache_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanupThumbnailCacheRemovesOldestEntries(t *testing.T) {
+	dir := t.TempDir()
+	oldest := filepath.Join(dir, "oldest.jpg")
+	middle := filepath.Join(dir, "middle.jpg")
+	newest := filepath.Join(dir, "newest.jpg")
+	for _, file := range []string{oldest, middle, newest} {
+		if err := os.WriteFile(file, []byte("123456"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now()
+	if err := os.Chtimes(oldest, now.Add(-3*time.Hour), now.Add(-3*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(middle, now.Add(-2*time.Hour), now.Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newest, now.Add(-time.Hour), now.Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cleanupThumbnailCache(dir, 12, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(oldest); !os.IsNotExist(err) {
+		t.Fatalf("oldest thumbnail still exists, stat error=%v", err)
+	}
+	for _, file := range []string{middle, newest} {
+		if _, err := os.Stat(file); err != nil {
+			t.Fatalf("expected thumbnail %s to remain: %v", file, err)
+		}
+	}
+}
+
+func TestCleanupThumbnailCacheRemovesStaleTemporaryFiles(t *testing.T) {
+	dir := t.TempDir()
+	temp := filepath.Join(dir, ".thumbnail-stale.jpg")
+	if err := os.WriteFile(temp, []byte("temporary"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-thumbnailTempTTL - time.Minute)
+	if err := os.Chtimes(temp, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cleanupThumbnailCache(dir, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(temp); !os.IsNotExist(err) {
+		t.Fatalf("stale temporary thumbnail still exists, stat error=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- cap thumbnails at 256 MiB and 4096 cached files
- periodically remove the oldest thumbnails when limits are exceeded
- remove stale ffmpeg temporary files after 10 minutes while preserving active temporary files
- enforce limits immediately after creating a new thumbnail

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`