### PR TITLE
fix: open files beneath allowed roots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/joho/godotenv v1.5.1
 	github.com/mholt/archives v0.1.5
+	golang.org/x/sys v0.47.0
 )
 
 require (
@@ -26,6 +27,5 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
-	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.29.0 // indirect
 )

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -104,9 +104,10 @@ func (h *Handler) cleanupThumbnailCacheIfDue(dir string, force bool) error {
 	return cleanupThumbnailCache(dir, thumbnailMaxBytes, thumbnailMaxFiles)
 }
 
-func (h *Handler) generateThumbnail(ctx context.Context, videoPath, thumbnailPath string) error {
+func (h *Handler) generateThumbnail(ctx context.Context, videoPath, thumbnailPath string, extraFiles ...*os.File) error {
 	// ffmpeg command to generate thumbnail
 	cmd := exec.CommandContext(ctx, "ffmpeg", "-i", videoPath, "-ss", "00:00:01", "-vframes", "1", "-vf", "thumbnail,scale=320:-1", "-y", thumbnailPath)
+	cmd.ExtraFiles = extraFiles
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Check if the error is due to context timeout
@@ -154,7 +155,13 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer release(h.thumbnailGate)
-	info, err := os.Stat(fullPath)
+	source, err := h.openAllowedPath(fullPath, os.O_RDONLY, 0)
+	if err != nil {
+		h.respondError(w, "Cannot inspect video", http.StatusBadRequest)
+		return
+	}
+	info, err := source.Stat()
+	_ = source.Close()
 	if err != nil || info.IsDir() {
 		h.respondError(w, "Cannot inspect video", http.StatusBadRequest)
 		return
@@ -173,6 +180,11 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 
 	// generate thumbnail
 	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
+		source, err := h.openAllowedPath(fullPath, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = source.Close() }()
 		tmp, err := os.CreateTemp(thumbnailDir, ".thumbnail-*.jpg")
 		if err != nil {
 			return err
@@ -184,7 +196,8 @@ func (h *Handler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		defer func() { _ = os.Remove(tmpPath) }()
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		if err := h.generateThumbnail(ctx, fullPath, tmpPath); err != nil {
+		videoPath, extraFiles := childProcessFilePath(source, fullPath)
+		if err := h.generateThumbnail(ctx, videoPath, tmpPath, extraFiles...); err != nil {
 			return err
 		}
 		if err := os.Rename(tmpPath, thumbnailPath); err != nil {
@@ -856,7 +869,7 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, err := os.Open(fullPath)
+	file, err := h.openAllowedPath(fullPath, os.O_RDONLY, 0)
 	if err != nil {
 		h.logger.Warn("Cannot open file for download", "path", fullPath, "error", err)
 		h.respondError(w, "Cannot open file", http.StatusNotFound)
@@ -914,7 +927,14 @@ func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stat, err := os.Stat(fullPath)
+	file, err := h.openAllowedPath(fullPath, os.O_RDONLY, 0)
+	if err != nil {
+		h.logger.Warn("Cannot get file info for content", "path", fullPath, "error", err)
+		h.respondError(w, "Cannot get file info", http.StatusNotFound)
+		return
+	}
+	defer func() { _ = file.Close() }()
+	stat, err := file.Stat()
 	if err != nil {
 		h.logger.Warn("Cannot get file info for content", "path", fullPath, "error", err)
 		h.respondError(w, "Cannot get file info", http.StatusNotFound)
@@ -932,7 +952,7 @@ func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
 	// 画像ファイルの場合はhttp.ServeFileで最適化
 	if mimeType != "" && strings.HasPrefix(mimeType, "image/") {
 		w.Header().Set("Cache-Control", "max-age=3600")
-		http.ServeFile(w, r, fullPath)
+		http.ServeContent(w, r, filepath.Base(path), stat.ModTime(), file)
 		return
 	}
 
@@ -956,7 +976,10 @@ func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
 
 	// 並列処理でファイル読み込み
 	resultChan := worker.SubmitWithResult(h.workerPool, func() interface{} {
-		content, err := os.ReadFile(fullPath)
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		content, err := io.ReadAll(file)
 		if err != nil {
 			h.logger.Error("Failed to read file content", "path", fullPath, "error", err)
 			return nil
@@ -1111,7 +1134,14 @@ func (h *Handler) createZipArchive(ctx context.Context, w io.Writer, paths []str
 				return
 			}
 
-			fileInfo, err := os.Stat(fullPath)
+			file, err := h.openAllowedPath(fullPath, os.O_RDONLY, 0)
+			if err != nil {
+				h.logger.Error("Failed to stat file for zipping", "path", fullPath, "error", err)
+				atomic.AddInt64(&failedFiles, 1)
+				return
+			}
+			fileInfo, err := file.Stat()
+			_ = file.Close()
 			if err != nil {
 				h.logger.Error("Failed to stat file for zipping", "path", fullPath, "error", err)
 				atomic.AddInt64(&failedFiles, 1)
@@ -1214,8 +1244,14 @@ func (h *Handler) addFileToZip(ctx context.Context, zipWriter *zip.Writer, fileP
 	if ctx.Err() != nil {
 		return false
 	}
-	info, err := os.Stat(filePath)
+	file, err := h.openAllowedPath(filePath, os.O_RDONLY, 0)
 	if err != nil {
+		h.logger.Error("Failed to stat file for zipping", "path", filePath, "error", err)
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
 		h.logger.Error("Failed to stat file for zipping", "path", filePath, "error", err)
 		return false
 	}
@@ -1229,11 +1265,6 @@ func (h *Handler) addFileToZip(ctx context.Context, zipWriter *zip.Writer, fileP
 	header.Name = filepath.ToSlash(zipPath)
 	header.Method = zip.Deflate
 
-	file, err := os.Open(filePath)
-	if err != nil {
-		h.logger.Error("Failed to open file for zipping", "path", filePath, "error", err)
-		return false
-	}
 	defer func() {
 		if err := file.Close(); err != nil {
 			h.logger.Error("Failed to close file for zipping", "path", filePath, "error", err)

--- a/handlers/safe_open.go
+++ b/handlers/safe_open.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// openAllowedPath resolves the allowed root once and opens the target beneath
+// that directory. The platform implementation uses the strongest available
+// path-confinement primitive so a symlink swap cannot redirect the open outside
+// the configured root.
+func (h *Handler) openAllowedPath(path string, flags int, perm os.FileMode) (*os.File, error) {
+	root, relative, err := h.allowedRootForPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return openBeneath(root, relative, flags, perm)
+}
+
+func (h *Handler) allowedRootForPath(path string) (string, string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", fmt.Errorf("could not get absolute path: %w", err)
+	}
+	resolvedPath, err := resolveExistingPath(filepath.Clean(absPath))
+	if err != nil {
+		return "", "", err
+	}
+
+	allowedDirs := make([]string, 0, len(h.config.MountDirs)+1+len(h.config.SpecificDirs))
+	allowedDirs = append(allowedDirs, h.config.MountDirs...)
+	allowedDirs = append(allowedDirs, h.config.StorageDir)
+	allowedDirs = append(allowedDirs, h.config.SpecificDirs...)
+	for _, allowedDir := range allowedDirs {
+		absAllowed, err := filepath.Abs(allowedDir)
+		if err != nil {
+			continue
+		}
+		resolvedAllowed, err := resolveExistingPath(filepath.Clean(absAllowed))
+		if err != nil || !isPathWithin(resolvedAllowed, resolvedPath) {
+			continue
+		}
+		relative, err := filepath.Rel(resolvedAllowed, resolvedPath)
+		if err != nil {
+			continue
+		}
+		return resolvedAllowed, relative, nil
+	}
+
+	return "", "", fmt.Errorf("path is not in an allowed directory: %s", path)
+}

--- a/handlers/safe_open_linux.go
+++ b/handlers/safe_open_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package handlers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func openBeneath(root, relative string, flags int, perm os.FileMode) (*os.File, error) {
+	rootFD, err := unix.Open(root, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unix.Close(rootFD) }()
+
+	if relative == "." {
+		relative = ""
+	}
+	if filepath.IsAbs(relative) || relative == ".." || (len(relative) >= 3 && relative[:3] == ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("path escapes allowed root")
+	}
+
+	how := &unix.OpenHow{
+		Flags:   uint64(flags) | unix.O_CLOEXEC,
+		Mode:    uint64(perm.Perm()),
+		Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS,
+	}
+	fd, err := unix.Openat2(rootFD, relative, how)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), filepath.Join(root, relative)), nil
+}
+
+func childProcessFilePath(file *os.File, original string) (string, []*os.File) {
+	return "/proc/self/fd/3", []*os.File{file}
+}

--- a/handlers/safe_open_other.go
+++ b/handlers/safe_open_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Non-Linux builds retain the existing behavior; Linux deployments use
+// openat2(2) through safe_open_linux.go for race-resistant path confinement.
+func openBeneath(root, relative string, flags int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(filepath.Join(root, relative), flags, perm)
+}
+
+func childProcessFilePath(_ *os.File, original string) (string, []*os.File) {
+	return original, nil
+}

--- a/handlers/safe_open_test.go
+++ b/handlers/safe_open_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"puremania/types"
+)
+
+func TestOpenAllowedPathRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHandler(&types.Config{StorageDir: root}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if _, err := h.openAllowedPath(filepath.Join(root, "link", "secret.txt"), os.O_RDONLY, 0); err == nil {
+		t.Fatal("expected a symlink escaping the configured root to be rejected")
+	}
+}
+
+func TestOpenAllowedPathReadsWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file.txt")
+	if err := os.WriteFile(path, []byte("content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHandler(&types.Config{StorageDir: root}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	file, err := h.openAllowedPath(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "content" {
+		t.Fatalf("content = %q, want content", content)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Linux `openat2(2)` helper using `RESOLVE_BENEATH` and `RESOLVE_NO_MAGICLINKS`
- open download, content, ZIP, and thumbnail inputs beneath configured allowed roots
- pass the verified thumbnail input file descriptor to ffmpeg
- add a non-Linux compatibility implementation and symlink escape tests

This hardens read/open paths and ffmpeg inputs. Directory-based write operations remain atomic via their existing temp-file flow and are candidates for a follow-up dirfd-based rename hardening.

## Validation
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go mod tidy`
- `git diff --check`