### PR TITLE
test: add security fuzz coverage

### DIFF
--- a/handlers/security_fuzz_test.go
+++ b/handlers/security_fuzz_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzParseContentRange(f *testing.F) {
+	for _, seed := range []string{
+		"bytes 0-9/10",
+		"bytes 1-0/2",
+		"bytes -1-4/5",
+		"bytes 9223372036854775807-9223372036854775807/9223372036854775807",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(_ *testing.T, value string) {
+		_, _, _, _ = parseContentRange(value)
+	})
+}
+
+func FuzzSecureJoin(f *testing.F) {
+	for _, seed := range []string{"file.txt", "../outside", "a/../../b", "link/file"} {
+		f.Add(seed)
+	}
+	base := f.TempDir()
+	f.Fuzz(func(_ *testing.T, relative string) {
+		_, _ = secureJoin(base, relative)
+	})
+}
+
+func FuzzValidateBatchPaths(f *testing.F) {
+	for _, seed := range []string{"/file.txt", "/a\x00/b", strings.Repeat("x", maxVirtualPathBytes+1)} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(_ *testing.T, value string) {
+		_ = validateBatchPaths(strings.Split(value, "\x00"))
+	})
+}
+
+func FuzzContentDisposition(f *testing.F) {
+	for _, seed := range []string{"file.txt", "report\".txt", "line\r\nX-Injected: true", "日本語.txt"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, filename string) {
+		formatted := contentDisposition(filename)
+		if strings.ContainsAny(formatted, "\r\n") {
+			t.Fatalf("formatted filename contains a line break: %q", formatted)
+		}
+	})
+}

--- a/security_fuzz_test.go
+++ b/security_fuzz_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func FuzzSelectContentEncoding(f *testing.F) {
+	for _, seed := range []string{"gzip, br", "br;q=0, gzip;q=1", "gzip;q=0.5, *;q=0.2", "\x00\r\n"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(_ *testing.T, value string) {
+		encoding := selectContentEncoding(value)
+		if encoding != "" && encoding != "br" && encoding != "gzip" {
+			panic("unexpected content encoding")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- fuzz Content-Range parsing and secure path joining
- fuzz batch path validation and Content-Disposition formatting
- fuzz response content-encoding negotiation

## Validation
- `go test ./...`
- `go test -race ./...`
- `go test ./handlers -run=FuzzParseContentRange -fuzz=FuzzParseContentRange -fuzztime=3s`
- `git diff --check`