### PR TITLE
fix: cap prepared zip downloads

### DIFF
--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -1054,12 +1054,13 @@ func (h *Handler) DownloadZip(w http.ResponseWriter, r *http.Request) {
 	}
 	token := hex.EncodeToString(tokenBytes)
 	expiresAt := time.Now().Add(time.Hour)
-	h.zipDownloads.Store(token, preparedZip{path: tmpPath, expiresAt: expiresAt})
+	if !h.storePreparedZip(token, preparedZip{path: tmpPath, expiresAt: expiresAt}) {
+		h.respondError(w, "Too many prepared downloads", http.StatusTooManyRequests)
+		return
+	}
 	removeTemp = false
 	time.AfterFunc(time.Until(expiresAt), func() {
-		if value, loaded := h.zipDownloads.LoadAndDelete(token); loaded {
-			_ = os.Remove(value.(preparedZip).path)
-		}
+		h.expirePreparedZip(token)
 	})
 	h.respondSuccess(w, map[string]string{"downloadUrl": "/api/files/download-zip/" + token})
 }
@@ -1068,12 +1069,11 @@ func (h *Handler) DownloadPreparedZip(w http.ResponseWriter, r *http.Request) {
 	token := mux.Vars(r)["token"]
 	// A prepared archive is a one-time capability. Consume the token before
 	// opening the file so concurrent requests cannot replay the same archive.
-	value, ok := h.zipDownloads.LoadAndDelete(token)
+	prepared, ok := h.takePreparedZip(token)
 	if !ok {
 		h.respondError(w, "Download not found or expired", http.StatusNotFound)
 		return
 	}
-	prepared := value.(preparedZip)
 	defer func() { _ = os.Remove(prepared.path) }()
 	if time.Now().After(prepared.expiresAt) {
 		h.respondError(w, "Download expired", http.StatusGone)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -28,6 +28,8 @@ type Handler struct {
 	thumbnailGate        chan struct{}   // bounds concurrent ffmpeg work
 	searchGate           chan struct{}   // bounds concurrent recursive searches
 	zipDownloads         sync.Map        // token -> preparedZip; entries expire after download preparation
+	zipDownloadsMu       sync.Mutex
+	preparedZipCount     int
 	thumbnailCleanupMu   sync.Mutex
 	lastThumbnailCleanup time.Time
 }

--- a/handlers/prepared_zip.go
+++ b/handlers/prepared_zip.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"os"
+	"time"
+)
+
+const maxPreparedZips = 8
+
+// storePreparedZip bounds archives waiting for their one-time download URL.
+// This protects /tmp even when callers create archives but never follow the
+// returned URL.
+func (h *Handler) storePreparedZip(token string, prepared preparedZip) bool {
+	h.zipDownloadsMu.Lock()
+	now := time.Now()
+	var expiredPaths []string
+	h.zipDownloads.Range(func(key, value interface{}) bool {
+		entry, ok := value.(preparedZip)
+		if !ok || now.Before(entry.expiresAt) {
+			return true
+		}
+		if _, loaded := h.zipDownloads.LoadAndDelete(key); loaded {
+			if h.preparedZipCount > 0 {
+				h.preparedZipCount--
+			}
+			expiredPaths = append(expiredPaths, entry.path)
+		}
+		return true
+	})
+	if h.preparedZipCount >= maxPreparedZips {
+		h.zipDownloadsMu.Unlock()
+		removePreparedZipFiles(expiredPaths)
+		return false
+	}
+	h.zipDownloads.Store(token, prepared)
+	h.preparedZipCount++
+	h.zipDownloadsMu.Unlock()
+	removePreparedZipFiles(expiredPaths)
+	return true
+}
+
+func (h *Handler) takePreparedZip(token string) (preparedZip, bool) {
+	value, loaded := h.zipDownloads.LoadAndDelete(token)
+	if !loaded {
+		return preparedZip{}, false
+	}
+	h.zipDownloadsMu.Lock()
+	if h.preparedZipCount > 0 {
+		h.preparedZipCount--
+	}
+	h.zipDownloadsMu.Unlock()
+	prepared, ok := value.(preparedZip)
+	return prepared, ok
+}
+
+func (h *Handler) expirePreparedZip(token string) {
+	prepared, ok := h.takePreparedZip(token)
+	if ok {
+		_ = os.Remove(prepared.path)
+	}
+}
+
+func removePreparedZipFiles(paths []string) {
+	for _, path := range paths {
+		_ = os.Remove(path)
+	}
+}

--- a/handlers/prepared_zip_test.go
+++ b/handlers/prepared_zip_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"puremania/types"
+)
+
+func TestStorePreparedZipCapsUnconsumedArchives(t *testing.T) {
+	h := NewHandler(&types.Config{StorageDir: t.TempDir()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	expiresAt := time.Now().Add(time.Hour)
+	for i := 0; i < maxPreparedZips; i++ {
+		if !h.storePreparedZip(string(rune('a'+i)), preparedZip{expiresAt: expiresAt}) {
+			t.Fatalf("archive %d was rejected before the configured cap", i)
+		}
+	}
+	if h.storePreparedZip("overflow", preparedZip{expiresAt: expiresAt}) {
+		t.Fatal("expected an unconsumed archive over the cap to be rejected")
+	}
+
+	for i := 0; i < maxPreparedZips; i++ {
+		h.expirePreparedZip(string(rune('a' + i)))
+	}
+}
+
+func TestStorePreparedZipSweepsExpiredArchives(t *testing.T) {
+	h := NewHandler(&types.Config{StorageDir: t.TempDir()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.zipDownloads.Store("expired", preparedZip{expiresAt: time.Now().Add(-time.Second)})
+	if !h.storePreparedZip("fresh", preparedZip{expiresAt: time.Now().Add(time.Hour)}) {
+		t.Fatal("expected expired archive to be swept before applying the cap")
+	}
+	if _, ok := h.zipDownloads.Load("expired"); ok {
+		t.Fatal("expired archive remained in the download map")
+	}
+	h.expirePreparedZip("fresh")
+}


### PR DESCRIPTION
## Summary
- cap unconsumed prepared ZIP downloads at eight entries
- sweep expired entries before accepting a new prepared archive
- remove expired archive files and keep one-time download consumption accounting consistent
- add regression tests for the cap and expiry sweep

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`