### PR TITLE
refactor: migrate legacy overlays to native dialogs

### DIFF
--- a/static/css/components/editor.css
+++ b/static/css/components/editor.css
@@ -1,9 +1,9 @@
 /* Editor Modal */
 .editor-modal {
-    /* Uses .modal-overlay styles for backdrop */
+    /* Uses dialog::backdrop for the modal backdrop */
 }
 
-.editor-modal .modal {
+.editor-modal .dialog-panel {
     width: 90vw;
     height: 90vh;
     max-width: 1600px; /* Add a max-width for very large screens */
@@ -15,7 +15,7 @@
 }
 
 /* Editor Header */
-.editor-modal .modal-header {
+.editor-modal .dialog-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -37,7 +37,7 @@
 }
 
 /* Editor Body */
-.editor-modal .modal-body {
+.editor-modal .dialog-body {
     padding: 0;
     flex-grow: 1; /* Allow body to fill available space */
     overflow: hidden; /* CM scroller will handle scrolling */

--- a/static/css/components/image-viewer.css
+++ b/static/css/components/image-viewer.css
@@ -5,7 +5,7 @@
   height: 100%;
 }
 
-.image-viewer .modal {
+.image-viewer .dialog-panel {
     max-width: 95vw;
     max-height: 95vh;
     width: auto;
@@ -14,14 +14,14 @@
     flex-direction: column;
 }
 
-.image-viewer .modal-header {
+.image-viewer .dialog-header {
     flex-shrink: 0;
     padding: 15px 20px;
     border-bottom: 1px solid var(--border-color);
     background-color: var(--bg-secondary);
 }
 
-.image-viewer .modal-body {
+.image-viewer .dialog-body {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -152,7 +152,7 @@
 }
 
 /* フルスクリーンモード */
-.image-viewer.fullscreen .modal {
+.image-viewer.fullscreen .dialog-panel {
     max-width: 100vw;
     max-height: 100vh;
     width: 100vw;
@@ -161,7 +161,7 @@
     border-radius: 0;
 }
 
-.image-viewer.fullscreen .modal-header {
+.image-viewer.fullscreen .dialog-header {
     position: fixed;
     top: 0;
     left: 0;
@@ -169,7 +169,7 @@
     z-index: 100;
 }
 
-.image-viewer.fullscreen .modal-body {
+.image-viewer.fullscreen .dialog-body {
     padding-top: 60px; /* ヘッダーの高さ分 */
 }
 
@@ -181,7 +181,7 @@
     z-index: 100;
 }
 
-.modal-header .modal-actions .zoom-btn {
+.dialog-header .dialog-actions .zoom-btn {
     display: none;
 }
 
@@ -206,7 +206,7 @@
 }
 
 /* フルスクリーン時のズームコントロールだけ右下に固定 */
-.modal-overlay.fullscreen .image-container > .image-zoom-controls {
+.dialog-overlay.fullscreen .image-container > .image-zoom-controls {
     position: absolute;
     bottom: 70px;   /* 下からの距離 */
     right: 20px;    /* 右からの距離 */
@@ -219,7 +219,7 @@
 }
 
 /* ボタン自体のサイズや見た目を微調整 */
-.modal-overlay.fullscreen .image-container > .image-zoom-controls .zoom-btn {
+.dialog-overlay.fullscreen .image-container > .image-zoom-controls .zoom-btn {
     font-size: 18px;
     color: #fff;
     background: none;

--- a/static/css/components/media-player.css
+++ b/static/css/components/media-player.css
@@ -219,14 +219,14 @@
   display: none;
 }
 
-.video-modal .modal {
+.video-modal .dialog-panel {
   width: min(1100px, 95vw);
   max-height: 92vh;
   display: flex;
   flex-direction: column;
 }
 
-.video-modal .modal-header {
+.video-modal .dialog-header {
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -237,7 +237,7 @@
   gap: 3px;
 }
 
-.video-modal .modal-title {
+.video-modal .dialog-title {
   max-width: min(70vw, 900px);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -262,14 +262,14 @@
 }
 
 @media (max-width: 768px) {
-  .video-modal .modal {
+  .video-modal .dialog-panel {
     width: 100vw;
     max-height: 100vh;
     max-width: 100vw;
     border-radius: 0;
   }
 
-  .video-modal .modal-header {
+  .video-modal .dialog-header {
     padding: 10px 12px;
   }
 

--- a/static/css/components/modal.css
+++ b/static/css/components/modal.css
@@ -1,18 +1,30 @@
-/* Modal Styles */
-.modal-overlay {
+/* Native dialog styles */
+dialog.dialog-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
 }
 
-.modal {
+dialog.dialog-overlay:not([open]) {
+  display: none;
+}
+
+dialog.dialog-overlay::backdrop {
+  background: rgb(0 0 0 / 70%);
+  backdrop-filter: blur(2px);
+}
+
+.dialog-panel {
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 4px;
@@ -22,7 +34,7 @@
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
 }
 
-.modal-header {
+.dialog-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -31,17 +43,17 @@
     color: white;
 }
 
-.modal-title {
+.dialog-title {
     font-size: 1rem;
     font-weight: bold;
 }
 
-.modal-actions {
+.dialog-actions {
     display: flex;
     gap: 8px; /* ボタン間のスペース */
 }
 
-.modal-actions > button {
+.dialog-actions > button {
     background-color: rgba(0,0,0,0.6);
     border: none;
     color: white;
@@ -56,12 +68,12 @@
     transition: all 0.2s ease;
 }
 
-.modal-actions > button:hover {
+.dialog-actions > button:hover {
     background-color: rgba(255,255,255,0.2);
     transform: scale(1.1);
 }
 
-.modal-close {
+.dialog-close {
   background: none;
   border: none;
   color: var(--text-secondary);
@@ -72,16 +84,16 @@
   height: 30px;
 }
 
-.modal-close:hover {
+.dialog-close:hover {
   color: var(--accent-primary);
 }
 
-.modal-body {
+.dialog-body {
   padding: 10px;
   overflow: auto;
 }
 
-.modal-footer {
+.dialog-footer {
   padding: 15px 20px;
   border-top: 1px solid var(--border-color);
   display: flex;
@@ -149,15 +161,44 @@
   gap: 10px;
 }
 
-/* Aria2c Download Modal */
-#aria2c-status-modal .modal-content {
-    width: 800px;
+.aria2c-dialog {
+    width: min(800px, calc(100vw - 32px));
     max-width: 95vw;
+    max-height: 90vh;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    box-shadow: 0 20px 40px rgb(0 0 0 / 35%);
 }
 
-#aria2c-status-modal .modal-body {
+.aria2c-dialog::backdrop {
+    background: rgb(0 0 0 / 65%);
+    backdrop-filter: blur(2px);
+}
+
+.aria2c-dialog__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.aria2c-dialog__header h2 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.aria2c-dialog__header form {
+    margin: 0;
+}
+
+.aria2c-dialog__body {
     max-height: 70vh;
     overflow-y: auto;
+    padding: 10px;
 }
 
 .download-list {

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -55,7 +55,7 @@
         margin-bottom: 5px;
     }
 
-    .image-viewer .modal {
+    .image-viewer .dialog-panel {
         max-width: 100vw;
         max-height: 100vh;
         margin: 0;
@@ -193,7 +193,7 @@
 }
 
 @media (max-width: 968px) {
-  .editor-modal .modal {
+  .editor-modal .dialog-panel {
     max-width: 95%;
     max-height: 95%;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pure Mania</title>
-    <link rel="stylesheet" href="/static/css/style.css?v=EREIDP46">
-    <link rel="stylesheet" href="/static/css/masonry.css?v=EREIDP46">
-    <link rel="stylesheet" href="/static/css/components/video-view.css?v=EREIDP46">
+    <link rel="stylesheet" href="/static/css/style.css?v=OZXSK7KM">
+    <link rel="stylesheet" href="/static/css/masonry.css?v=OZXSK7KM">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?v=OZXSK7KM">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>
@@ -16,10 +16,10 @@
     <script type="module">
         const root = document.getElementById('app-root');
         try {
-            const response = await fetch('/static/templates/app_shell.html?v=EREIDP46');
+            const response = await fetch('/static/templates/app_shell.html?v=OZXSK7KM');
             if (!response.ok) throw new Error(`App shell request failed (${response.status})`);
             root.innerHTML = await response.text();
-            await import('/static/dist/app-EREIDP46.js');
+            await import('/static/dist/app-OZXSK7KM.js');
         } catch (error) {
             console.error('Failed to load the application shell', error);
             root.textContent = 'Failed to load the application. Please reload.';

--- a/static/js/dialog-markup.test.mjs
+++ b/static/js/dialog-markup.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const template = relativePath => readFile(new URL(`../templates/${relativePath}`, import.meta.url), 'utf8');
+
+test('the static Aria2c dialog uses the native dialog element', async () => {
+    const appShell = await template('app_shell.html');
+    assert.match(appShell, /<dialog id="aria2cStatusDialog"/);
+    assert.doesNotMatch(appShell, /id="aria2c-status-modal"/);
+});
+
+test('dynamic dialog templates do not reintroduce legacy modal panels', async () => {
+    const [searchModal, imageViewer] = await Promise.all([
+        template('components/search_modal.html'),
+        template('components/image_viewer.html')
+    ]);
+
+    for (const markup of [searchModal, imageViewer]) {
+        assert.doesNotMatch(markup, /class="modal"/);
+        assert.match(markup, /class="dialog-panel"/);
+    }
+});

--- a/static/js/file-editor.js
+++ b/static/js/file-editor.js
@@ -18,7 +18,7 @@ import { html } from "@codemirror/lang-html";
 import { css } from "@codemirror/lang-css";
 import { xml } from "@codemirror/lang-xml";
 import { markdown } from "@codemirror/lang-markdown";
-import { createModalOverlay, hideModalOverlay, showModalOverlay } from "./modal.js";
+import { bindModalClose, createModalOverlay, hideModalOverlay, showModalOverlay } from "./modal.js";
 
 const getLanguageName = (filePath) => {
     const extension = filePath.split('.').pop().toLowerCase();
@@ -116,18 +116,18 @@ export class FileEditor {
         ` : '';
 
         const editorMarkup = `
-            <div class="modal">
-                <div class="modal-header">
+            <div class="dialog-panel">
+                <div class="dialog-header">
                     <div class="editor-filename"></div>
                     <div class="editor-actions">
                         <button class="btn" id="editor-cancel">Close</button>
                         <button class="btn btn-primary" id="editor-save">Save</button>
                     </div>
                 </div>
-                <div class="modal-body">
+                <div class="dialog-body">
                     <div class="editor-container"></div>
                 </div>
-                <div class="modal-footer editor-status-bar">
+                <div class="dialog-footer editor-status-bar">
                     <div class="status-left">
                         <span id="status-cursor">Ln 1, Col 1</span>
                         <span id="status-selection"></span>
@@ -141,7 +141,7 @@ export class FileEditor {
             </div>
         `;
 
-        const editor = createModalOverlay({ className: 'editor-modal', hidden: true, content: editorMarkup });
+        const editor = createModalOverlay({ className: 'editor-modal', content: editorMarkup });
         this.editorElement = editor;
         this.editorContainer = editor.querySelector('.editor-container');
         this.filenameElement = editor.querySelector('.editor-filename');
@@ -156,6 +156,7 @@ export class FileEditor {
         }
 
         this.bindEvents();
+        this.unbindModalClose = bindModalClose(this.editorElement, { onClose: () => this.close() });
     }
 
     bindEvents() {
@@ -270,7 +271,7 @@ export class FileEditor {
     }
 
     close() {
-        if (this.editorElement.style.display === 'none') {
+        if (!this.editorElement.open) {
             return;
         }
         if (this.editorView && this.editorView.state.doc.toString() !== this.savedContent && !window.confirm('Discard unsaved changes?')) return;

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -20,10 +20,10 @@ export class ImageViewer {
     
     createViewerElement() {
         const template = getTemplateContent(TEMPLATES.imageViewer);
-        const viewer = createModalOverlay({ className: 'image-viewer', hidden: true, content: template });
+        const viewer = createModalOverlay({ className: 'image-viewer', content: template });
         this.viewerElement = viewer;
         this.imageElement = viewer.querySelector('img');
-        this.titleElement = viewer.querySelector('.modal-title');
+        this.titleElement = viewer.querySelector('.dialog-title');
         this.nameElement = viewer.querySelector('.image-name');
         this.sizeElement = viewer.querySelector('.image-size');
         this.prevButton = viewer.querySelector('.prev');
@@ -75,7 +75,7 @@ export class ImageViewer {
         }
         
         this.showImage(this.currentImageIndex);
-        showModalOverlay(this.viewerElement, { initialFocus: this.viewerElement.querySelector('.modal-close') });
+        showModalOverlay(this.viewerElement, { initialFocus: this.viewerElement.querySelector('.dialog-close') });
         this.isOpen = true;
         document.body.style.overflow = 'hidden';
         this.showNavButtons();

--- a/static/js/media-player.js
+++ b/static/js/media-player.js
@@ -619,21 +619,21 @@ export class MediaPlayer {
         const modal = createModalOverlay({
             className: 'video-modal',
             content: `
-            <div class="modal">
-                <div class="modal-header">
+            <div class="dialog-panel">
+                <div class="dialog-header">
                     <div class="video-modal-header-main">
-                        <div class="modal-title"></div>
+                        <div class="dialog-title"></div>
                         <div class="video-modal-meta">Esc: close / Space: play-pause / ← →: seek 5s</div>
                     </div>
-                    <button class="modal-close">&times;</button>
+                    <button class="dialog-close" type="button" aria-label="Close">&times;</button>
                 </div>
-                <div class="modal-body video-modal-body">
+                <div class="dialog-body video-modal-body">
                     <video class="video-modal-player" controls autoplay playsinline></video>
                 </div>
             </div>
         `
         });
-        const title = modal.querySelector('.modal-title');
+        const title = modal.querySelector('.dialog-title');
         title.textContent = fileName;
         title.title = fileName;
         const video = modal.querySelector('video');

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,13 +1,7 @@
-export function createModalOverlay({ className = '', hidden = false, content = null } = {}) {
-    const modal = document.createElement('div');
-    modal.className = `modal-overlay${className ? ` ${className}` : ''}`;
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
+export function createModalOverlay({ className = '', content = null } = {}) {
+    const modal = document.createElement('dialog');
+    modal.className = `dialog-overlay${className ? ` ${className}` : ''}`;
     modal.tabIndex = -1;
-    if (hidden) {
-        modal.style.display = 'none';
-        modal.setAttribute('aria-hidden', 'true');
-    }
 
     if (typeof content === 'string') {
         modal.innerHTML = content;
@@ -15,9 +9,9 @@ export function createModalOverlay({ className = '', hidden = false, content = n
         modal.appendChild(content);
     }
 
-    const title = modal.querySelector('.modal-title, .editor-title, h1, h2');
+    const title = modal.querySelector('.dialog-title, .editor-title, h1, h2');
     if (title) {
-        title.id ||= `modal-title-${createUniqueId()}`;
+        title.id ||= `dialog-title-${createUniqueId()}`;
         modal.setAttribute('aria-labelledby', title.id);
     } else {
         modal.setAttribute('aria-label', 'Dialog');
@@ -36,16 +30,14 @@ const focusableSelector = [
 export function showModalOverlay(modal, { initialFocus = null } = {}) {
     if (!modal) return;
     modal._previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    modal.style.display = 'flex';
-    modal.setAttribute('aria-hidden', 'false');
+    if (!modal.open) modal.showModal();
     const target = initialFocus || modal.querySelector(focusableSelector) || modal;
     requestAnimationFrame(() => target.focus());
 }
 
 export function hideModalOverlay(modal) {
     if (!modal) return;
-    modal.style.display = 'none';
-    modal.setAttribute('aria-hidden', 'true');
+    if (modal.open) modal.close();
     const previousFocus = modal._previousFocus;
     modal._previousFocus = null;
     if (previousFocus?.isConnected) previousFocus.focus();
@@ -56,38 +48,19 @@ export function bindModalClose(modal, { onClose, closeOnBackdrop = false } = {})
         return () => {};
     }
 
-    const closeButtons = Array.from(modal.querySelectorAll('.modal-close'));
+    const closeButtons = Array.from(modal.querySelectorAll('.dialog-close'));
     const clickHandler = (e) => {
         e.preventDefault();
         onClose(e);
     };
 
-    const keydownHandler = (event) => {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            onClose(event);
-            return;
-        }
-        if (event.key !== 'Tab') return;
-        const focusable = [...modal.querySelectorAll(focusableSelector)];
-        if (!focusable.length) {
-            event.preventDefault();
-            modal.focus();
-            return;
-        }
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (event.shiftKey && document.activeElement === first) {
-            event.preventDefault();
-            last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-            event.preventDefault();
-            first.focus();
-        }
+    const cancelHandler = (event) => {
+        event.preventDefault();
+        onClose(event);
     };
 
     closeButtons.forEach(btn => btn.addEventListener('click', clickHandler));
-    modal.addEventListener('keydown', keydownHandler);
+    modal.addEventListener('cancel', cancelHandler);
 
     let backdropHandler = null;
     if (closeOnBackdrop) {
@@ -101,7 +74,7 @@ export function bindModalClose(modal, { onClose, closeOnBackdrop = false } = {})
 
     return () => {
         closeButtons.forEach(btn => btn.removeEventListener('click', clickHandler));
-        modal.removeEventListener('keydown', keydownHandler);
+        modal.removeEventListener('cancel', cancelHandler);
         if (backdropHandler) {
             modal.removeEventListener('click', backdropHandler);
         }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -308,7 +308,7 @@ export class SearchHandler {
 
     createSearchModal() {
         const template = getTemplateContent(TEMPLATES.searchModal);
-        const modal = createModalOverlay({ className: 'search-modal', hidden: true, content: template });
+        const modal = createModalOverlay({ className: 'search-modal', content: template });
         this.searchModal = modal;
 
         modal.querySelector('#search-apply').addEventListener('click', () => {
@@ -330,7 +330,7 @@ export class SearchHandler {
 
     toggleSearchOptions() {
         if (this.searchModal) {
-            if (this.searchModal.style.display === 'none') {
+            if (!this.searchModal.open) {
                 showModalOverlay(this.searchModal);
             } else {
                 hideModalOverlay(this.searchModal);

--- a/static/templates/app_shell.html
+++ b/static/templates/app_shell.html
@@ -23,13 +23,16 @@
 </div>
 <div id="toast-container"></div>
 <div id="loading-overlay" style="display: none;" aria-hidden="true"><div class="loading-spinner"></div></div>
-<div id="aria2c-status-modal" class="modal" style="display: none;">
-    <div class="modal-content">
-        <div class="modal-header"><h2>Aria2c Downloads</h2><span class="close-button">&times;</span></div>
-        <div class="modal-body">
-            <div id="aria2c-active-downloads"><h3>Active</h3><div class="download-list"></div></div>
-            <div id="aria2c-waiting-downloads"><h3>Waiting</h3><div class="download-list"></div></div>
-            <div id="aria2c-stopped-downloads"><h3>Stopped/Finished</h3><div class="download-list"></div></div>
-        </div>
+<dialog id="aria2cStatusDialog" class="aria2c-dialog" aria-labelledby="aria2c-status-title">
+    <header class="aria2c-dialog__header">
+        <h2 id="aria2c-status-title">Aria2c Downloads</h2>
+        <form method="dialog">
+            <button class="dialog-close" type="submit" aria-label="Close">&times;</button>
+        </form>
+    </header>
+    <div class="aria2c-dialog__body">
+        <div id="aria2c-active-downloads"><h3>Active</h3><div class="download-list"></div></div>
+        <div id="aria2c-waiting-downloads"><h3>Waiting</h3><div class="download-list"></div></div>
+        <div id="aria2c-stopped-downloads"><h3>Stopped/Finished</h3><div class="download-list"></div></div>
     </div>
-</div>
+</dialog>

--- a/static/templates/components/image_viewer.html
+++ b/static/templates/components/image_viewer.html
@@ -1,10 +1,10 @@
 <template id="image-viewer-template">
-    <div class="modal">
-        <div class="modal-header">
-            <div class="modal-title"></div>
-            <button class="modal-close">&times;</button>
+    <div class="dialog-panel">
+        <div class="dialog-header">
+            <div class="dialog-title"></div>
+            <button class="dialog-close" type="button" aria-label="Close">&times;</button>
         </div>
-        <div class="modal-body">
+        <div class="dialog-body">
             <div class="image-container">
                 <img src="" alt="">
                 <button class="image-nav prev">◀</button>

--- a/static/templates/components/search_modal.html
+++ b/static/templates/components/search_modal.html
@@ -1,10 +1,10 @@
 <template id="search-modal-template">
-    <div class="modal">
-        <div class="modal-header">
-            <div class="modal-title">Search Options</div>
-            <button class="modal-close">&times;</button>
+    <div class="dialog-panel">
+        <div class="dialog-header">
+            <div class="dialog-title">Search Options</div>
+            <button class="dialog-close" type="button" aria-label="Close">&times;</button>
         </div>
-        <div class="modal-body">
+        <div class="dialog-body">
             <div class="search-option">
                 <label>
                     <input type="checkbox" id="search-use-regex">
@@ -25,7 +25,7 @@
                 </select>
             </div>
         </div>
-        <div class="modal-footer">
+        <div class="dialog-footer">
             <button class="btn btn-primary" id="search-apply">Apply</button>
             <button class="btn" id="search-cancel">Cancel</button>
         </div>


### PR DESCRIPTION
## Summary

- migrate the shared legacy modal overlay helper to native `<dialog>` elements
- replace legacy `.modal` panels and selectors with `dialog-*` components
- convert the static Aria2c status panel to an accessible `<dialog>`
- use native dialog `cancel` handling and `::backdrop` styling
- add markup contract tests to prevent legacy modal markup from returning

## Validation

- `npm test` (17 tests passed)
- `npm run build`
- JavaScript syntax checks
- `git diff --check`