### PR TITLE
refactor: use Popover API for search completions

### DIFF
--- a/static/css/components/context-menu.css
+++ b/static/css/components/context-menu.css
@@ -1,16 +1,25 @@
-/* Context Menu */
+/* Popover-ready context menu component. */
 .context-menu {
   position: fixed;
+  inset: auto;
   background-color: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  z-index: 1000;
-  min-width: 150px;
+  min-width: 200px;
+  max-width: min(20rem, calc(100vw - 1rem));
+  margin: 0;
+  padding: 4px;
 }
 
 .context-menu-item {
-  padding: 10px 15px;
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: start;
   cursor: pointer;
   transition: background-color 0.3s ease;
 }
@@ -23,16 +32,5 @@
 .context-menu-divider {
   height: 1px;
   background-color: var(--border-color);
-  margin: 5px 0;
-}
-
-/* コンテキストメニュー */
-.context-menu {
-  min-width: 200px;
-  display: none;
-}
-
-.context-menu-item {
-  padding: 12px 15px;
-  gap: 10px;
+  margin-block: 5px;
 }

--- a/static/css/components/search.css
+++ b/static/css/components/search.css
@@ -223,9 +223,8 @@
 /* CD command completion dropdown */
 .cd-completion-dropdown {
     position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
+    inset-block-start: 100%;
+    inset-inline: 0;
     z-index: 1000;
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);
@@ -235,6 +234,31 @@
     overflow-y: auto;
     margin-top: 2px;
     animation: slideDown 0.15s ease-out;
+}
+
+@supports (anchor-name: --search-input) {
+    .search-input {
+        anchor-name: --search-input;
+    }
+}
+
+@supports (position-anchor: --search-input) {
+    .cd-completion-dropdown:popover-open {
+        position: fixed;
+        inset: auto;
+        position-anchor: --search-input;
+        inset-block-start: anchor(bottom);
+        inset-inline-start: anchor(left);
+        width: anchor-size(width);
+        max-width: calc(100vw - 2rem);
+    }
+}
+
+@supports (position-area: block-end) {
+    .cd-completion-dropdown:popover-open {
+        position-area: block-end span-inline-end;
+        inset: auto;
+    }
 }
 
 .completion-list {

--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pure Mania</title>
-    <link rel="stylesheet" href="/static/css/style.css?v=OZXSK7KM">
-    <link rel="stylesheet" href="/static/css/masonry.css?v=OZXSK7KM">
-    <link rel="stylesheet" href="/static/css/components/video-view.css?v=OZXSK7KM">
+    <link rel="stylesheet" href="/static/css/style.css?v=63KI3HB6">
+    <link rel="stylesheet" href="/static/css/masonry.css?v=63KI3HB6">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?v=63KI3HB6">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>
@@ -16,10 +16,10 @@
     <script type="module">
         const root = document.getElementById('app-root');
         try {
-            const response = await fetch('/static/templates/app_shell.html?v=OZXSK7KM');
+            const response = await fetch('/static/templates/app_shell.html?v=63KI3HB6');
             if (!response.ok) throw new Error(`App shell request failed (${response.status})`);
             root.innerHTML = await response.text();
-            await import('/static/dist/app-OZXSK7KM.js');
+            await import('/static/dist/app-63KI3HB6.js');
         } catch (error) {
             console.error('Failed to load the application shell', error);
             root.textContent = 'Failed to load the application. Please reload.';

--- a/static/js/popover-structure.test.mjs
+++ b/static/js/popover-structure.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const readStatic = relativePath => readFile(new URL(`../${relativePath}`, import.meta.url), 'utf8');
+
+test('directory completions use a popover with a fallback path', async () => {
+    const searchSource = await readStatic('js/search.js');
+    assert.match(searchSource, /setAttribute\('popover', 'auto'\)/);
+    assert.match(searchSource, /showPopover\(\)/);
+    assert.match(searchSource, /hidePopover\(\)/);
+});
+
+test('completion styling declares an anchor-positioning enhancement', async () => {
+    const searchStyles = await readStatic('css/components/search.css');
+    assert.match(searchStyles, /anchor-name: --search-input/);
+    assert.match(searchStyles, /position-anchor: --search-input/);
+    assert.match(searchStyles, /position-area: block-end span-inline-end/);
+});
+
+test('context menu styles do not hide popover content with legacy display rules', async () => {
+    const contextMenuStyles = await readStatic('css/components/context-menu.css');
+    assert.doesNotMatch(contextMenuStyles, /display:\s*none/);
+    assert.match(contextMenuStyles, /popover-ready context menu/i);
+});

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -63,11 +63,21 @@ export class SearchHandler {
     createCompletionDropdown() {
         const dropdown = document.createElement('div');
         dropdown.className = 'cd-completion-dropdown';
-        dropdown.style.display = 'none';
+        dropdown.id = 'cdCompletion';
+        dropdown.setAttribute('popover', 'auto');
         const template = getTemplateContent(TEMPLATES.completionDropdown);
         dropdown.appendChild(template);
         document.querySelector('.search-container')?.appendChild(dropdown);
         this.completionDropdown = dropdown;
+
+        const searchInput = document.querySelector('.search-input');
+        searchInput?.setAttribute('aria-controls', dropdown.id);
+        dropdown.addEventListener('toggle', event => {
+            const open = event.newState === 'open';
+            this.isShowingCompletions = open;
+            searchInput?.setAttribute('aria-expanded', String(open));
+        });
+        if (typeof dropdown.showPopover !== 'function') dropdown.style.display = 'none';
     }
 
     setupFileOperationListeners() {
@@ -251,6 +261,8 @@ export class SearchHandler {
         completions.forEach((completion, index) => {
             const li = document.createElement('li');
             li.className = 'completion-item';
+            li.setAttribute('role', 'option');
+            li.setAttribute('aria-selected', 'false');
             const template = getTemplateContent(TEMPLATES.completionItem);
             template.querySelector('.completion-name').textContent = completion.name;
             template.querySelector('.completion-path').textContent = completion.fullPath;
@@ -275,7 +287,9 @@ export class SearchHandler {
 
     updateCompletionSelection() {
         this.completionDropdown.querySelectorAll('.completion-item').forEach((item, index) => {
-            item.classList.toggle('selected', index === this.selectedCompletionIndex);
+            const selected = index === this.selectedCompletionIndex;
+            item.classList.toggle('selected', selected);
+            item.setAttribute('aria-selected', String(selected));
         });
     }
 
@@ -293,14 +307,24 @@ export class SearchHandler {
 
     showCompletionsDropdown() {
         if (this.completionDropdown) {
-            this.completionDropdown.style.display = 'block';
+            if (typeof this.completionDropdown.showPopover === 'function') {
+                if (!this.completionDropdown.matches(':popover-open')) this.completionDropdown.showPopover();
+            } else {
+                this.completionDropdown.style.display = 'block';
+            }
+            document.querySelector('.search-input')?.setAttribute('aria-expanded', 'true');
             this.isShowingCompletions = true;
         }
     }
 
     hideCompletions() {
         if (this.completionDropdown) {
-            this.completionDropdown.style.display = 'none';
+            if (typeof this.completionDropdown.hidePopover === 'function') {
+                if (this.completionDropdown.matches(':popover-open')) this.completionDropdown.hidePopover();
+            } else {
+                this.completionDropdown.style.display = 'none';
+            }
+            document.querySelector('.search-input')?.setAttribute('aria-expanded', 'false');
             this.isShowingCompletions = false;
             this.selectedCompletionIndex = -1;
         }

--- a/static/templates/components/completion_dropdown.html
+++ b/static/templates/components/completion_dropdown.html
@@ -1,3 +1,3 @@
 <template id="completion-dropdown-template">
-    <ul class="completion-list"></ul>
+    <ul class="completion-list" role="listbox" aria-label="Directory completions"></ul>
 </template>


### PR DESCRIPTION
## Summary

- move directory completion visibility to the Popover API with a non-Popover fallback
- synchronize combobox state and completion option selection for assistive technology
- add CSS Anchor Positioning as a progressive enhancement for completion placement
- remove duplicate legacy context-menu CSS and make the component Popover-ready
- add frontend structure tests for the new behavior

## Validation

- `npm test` (20 tests passed)
- `npm run build`
- JavaScript syntax check
- `git diff --check`