### PR TITLE
refactor: improve semantic navigation and progress controls

### DIFF
--- a/static/css/components/file-browser.css
+++ b/static/css/components/file-browser.css
@@ -12,19 +12,36 @@
   border-radius: 4px;
   padding: 3px;
   width: fit-content;
+  border: 0;
 }
 
-.view-toggle-btn {
+.view-toggle-legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.view-toggle-option {
   padding: 5px 15px;
-  border: none;
-  background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   border-radius: 3px;
   font-family: 'Courier New', monospace;
 }
 
-.view-toggle-btn.active {
+.view-toggle-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.view-toggle-option:has(.view-toggle-input:checked) {
   background-color: var(--bg-tertiary);
   color: var(--accent-primary);
 }

--- a/static/css/components/search.css
+++ b/static/css/components/search.css
@@ -47,6 +47,9 @@
 }
 
 .search-options {
+  border: 0;
+  padding: 2px 0 2px 10px;
+  background: transparent;
   display: flex;
   align-items: center;
   margin-left: 10px;
@@ -56,6 +59,11 @@
 
 .search-options:hover {
   color: var(--accent-primary);
+}
+
+.search-options:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 /* Search Results Header */

--- a/static/css/layout/sidebar.css
+++ b/static/css/layout/sidebar.css
@@ -20,10 +20,19 @@
   text-shadow: 0 0 5px var(--accent-primary);
 }
 
+.file-navigation {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
 .nav-item {
   padding: 12px 20px;
   display: flex;
   align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
   cursor: pointer;
   transition: all 0.3s ease;
 }
@@ -39,8 +48,7 @@
   color: var(--accent-primary);
 }
 
-.nav-item i {
-  margin-right: 10px;
+.nav-icon {
   width: 20px;
   text-align: center;
 }
@@ -52,6 +60,9 @@
 }
 
 .storage-progress {
+  appearance: none;
+  display: block;
+  width: 100%;
   height: 5px;
   background-color: var(--bg-tertiary);
   border-radius: 3px;
@@ -59,11 +70,20 @@
   overflow: hidden;
 }
 
-#storage-progress-inner {
-  height: 100%;
+progress.storage-progress::-webkit-progress-bar {
+  background-color: var(--bg-tertiary);
+  border-radius: 3px;
+}
+
+progress.storage-progress::-webkit-progress-value {
   background-color: var(--accent-primary);
   border-radius: 3px;
   transition: width 0.3s ease;
+}
+
+progress.storage-progress::-moz-progress-bar {
+  background-color: var(--accent-primary);
+  border-radius: 3px;
 }
 
 /* Initially hide Aria2c button */

--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pure Mania</title>
-    <link rel="stylesheet" href="/static/css/style.css?v=63KI3HB6">
-    <link rel="stylesheet" href="/static/css/masonry.css?v=63KI3HB6">
-    <link rel="stylesheet" href="/static/css/components/video-view.css?v=63KI3HB6">
+    <link rel="stylesheet" href="/static/css/style.css?v=R2CI4ZAK">
+    <link rel="stylesheet" href="/static/css/masonry.css?v=R2CI4ZAK">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?v=R2CI4ZAK">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>
@@ -16,10 +16,10 @@
     <script type="module">
         const root = document.getElementById('app-root');
         try {
-            const response = await fetch('/static/templates/app_shell.html?v=63KI3HB6');
+            const response = await fetch('/static/templates/app_shell.html?v=R2CI4ZAK');
             if (!response.ok) throw new Error(`App shell request failed (${response.status})`);
             root.innerHTML = await response.text();
-            await import('/static/dist/app-63KI3HB6.js');
+            await import('/static/dist/app-R2CI4ZAK.js');
         } catch (error) {
             console.error('Failed to load the application shell', error);
             root.textContent = 'Failed to load the application. Please reload.';

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -106,10 +106,14 @@ class FileManagerApp {
         try {
             if (result.success) {
                 const info = result.data;
-                const usagePercentage = (info.used / info.total) * 100;
+                const usagePercentage = info.total > 0
+                    ? Math.min(100, Math.max(0, (info.used / info.total) * 100))
+                    : 0;
                 document.getElementById('storage-used').textContent = this.ui.formatFileSize(info.used);
                 document.getElementById('storage-total').textContent = this.ui.formatFileSize(info.total);
-                document.getElementById('storage-progress-inner').style.width = `${usagePercentage}%`;
+                const progress = document.getElementById('storage-progress');
+                progress.value = usagePercentage;
+                progress.textContent = `${Math.round(usagePercentage)}%`;
             } else {
                 console.error('Could not update storage info', result.message);
             }

--- a/static/js/events.js
+++ b/static/js/events.js
@@ -7,6 +7,7 @@ export class EventHandler {
         document.addEventListener('click', (e) => this.handleClick(e));
         document.addEventListener('dblclick', (e) => this.handleDoubleClick(e));
         document.addEventListener('keydown', (e) => this.handleKeydown(e));
+        document.addEventListener('change', (e) => this.handleChange(e));
 
         const fileBrowser = document.querySelector('.file-browser');
         if (fileBrowser) {
@@ -56,12 +57,6 @@ export class EventHandler {
             return;
         }
         
-        // View toggle buttons
-        if (e.target.matches('.view-toggle-btn')) {
-            this.app.ui.setViewMode(e.target.dataset.view);
-            return;
-        }
-
         if (e.target.id === 'toggle-file-browser-extensions-btn') {
             this.app.ui.toggleFileBrowserExtensions();
             return;
@@ -71,6 +66,12 @@ export class EventHandler {
         if (e.target.matches('.toolbar-btn')) {
             this.handleToolbarClick(e.target);
             return;
+        }
+    }
+
+    handleChange(e) {
+        if (e.target.matches('.view-toggle-input')) {
+            this.app.ui.setViewMode(e.target.value);
         }
     }
 

--- a/static/js/semantic-markup.test.mjs
+++ b/static/js/semantic-markup.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const template = relativePath => readFile(new URL(`../templates/${relativePath}`, import.meta.url), 'utf8');
+
+test('the shell exposes semantic navigation, search, and storage progress controls', async () => {
+    const appShell = await template('app_shell.html');
+    assert.match(appShell, /<nav class="file-navigation"/);
+    assert.match(appShell, /<a href="\/" class="nav-item active"/);
+    assert.match(appShell, /type="search"/);
+    assert.match(appShell, /role="combobox"/);
+    assert.match(appShell, /<progress class="storage-progress"/);
+    assert.doesNotMatch(appShell, /storage-progress-inner/);
+});
+
+test('view selection is represented as a native radio group', async () => {
+    const viewToggle = await template('components/view_toggle.html');
+    assert.match(viewToggle, /type="radio"/);
+    assert.match(viewToggle, /name="view-mode"/);
+    assert.doesNotMatch(viewToggle, /class="view-toggle-btn"/);
+});
+
+test('list timestamps use the time element', async () => {
+    const listItem = await template('components/list_view_item.html');
+    assert.match(listItem, /<time class="file-mod-time"><\/time>/);
+});

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -180,30 +180,40 @@ export class UIManager {
     }
 
     createViewToggle(hasMasonrySupport = false, hasVideoSupport = false) {
-        const viewToggle = document.createElement('div');
+        const viewToggle = document.createElement('fieldset');
         viewToggle.className = 'view-toggle';
+        const legend = document.createElement('legend');
+        legend.className = 'view-toggle-legend';
+        legend.textContent = 'View mode';
+        viewToggle.appendChild(legend);
         const template = getTemplateContent(TEMPLATES.viewToggle);
         
-        const activeBtn = template.querySelector(`[data-view="${this.viewMode}"]`);
+        const activeBtn = template.querySelector(`input[value="${this.viewMode}"]`);
         if (activeBtn) {
-            activeBtn.classList.add('active');
+            activeBtn.checked = true;
         }
 
         if (hasMasonrySupport) {
-            const masonryBtn = document.createElement('button');
-            masonryBtn.className = 'view-toggle-btn';
-            masonryBtn.dataset.view = 'masonry';
-            masonryBtn.textContent = 'Masonry';
+            const masonryOption = document.createElement('label');
+            masonryOption.className = 'view-toggle-option';
+            const masonryInput = document.createElement('input');
+            masonryInput.className = 'view-toggle-input';
+            masonryInput.type = 'radio';
+            masonryInput.name = 'view-mode';
+            masonryInput.value = 'masonry';
+            const masonryLabel = document.createElement('span');
+            masonryLabel.textContent = 'Masonry';
+            masonryOption.append(masonryInput, masonryLabel);
             if (this.viewMode === 'masonry') {
-                masonryBtn.classList.add('active');
+                masonryInput.checked = true;
             }
-            template.appendChild(masonryBtn);
+            template.appendChild(masonryOption);
         }
 
         if (!hasVideoSupport) {
-            const videoBtn = template.querySelector('[data-view="video"]');
+            const videoBtn = template.querySelector('input[value="video"]');
             if (videoBtn) {
-                videoBtn.remove();
+                videoBtn.closest('.view-toggle-option')?.remove();
             }
         }
 
@@ -554,7 +564,10 @@ export class UIManager {
         template.querySelector('.file-icon').className = `file-icon ${this.getFileIconClass(file)}`;
         template.querySelector('.file-name').textContent = file.name;
         template.querySelector('.file-size').textContent = file.is_dir ? '-' : this.formatFileSize(file.size);
-        template.querySelector('.file-mod-time').textContent = new Date(file.mod_time).toLocaleString();
+        const modified = new Date(file.mod_time);
+        const modifiedTime = template.querySelector('.file-mod-time');
+        modifiedTime.textContent = modified.toLocaleString();
+        if (!Number.isNaN(modified.getTime())) modifiedTime.dateTime = modified.toISOString();
         template.querySelector('.file-mime-type').textContent = file.is_dir ? 'Folder' : (file.mime_type || 'Unknown');
         
         const actionsContainer = template.querySelector('.file-actions');
@@ -779,13 +792,14 @@ export class UIManager {
         const iconMap = { 'Documents': '📄', 'Images': '🖼️', 'Music': '🎵', 'Videos': '🎬', 'Downloads': '📥', 'default': '📂' };
 
         dirs.forEach(dir => {
-            const navItem = document.createElement('div');
+            const navItem = document.createElement('a');
             navItem.className = 'nav-item';
             navItem.dataset.path = dir.path;
+            navItem.href = dir.path;
             
             const template = getTemplateContent(TEMPLATES.navItem);
-            template.querySelector('i').textContent = iconMap[dir.name] || iconMap['default'];
-            template.querySelector('span').textContent = dir.name;
+            template.querySelector('.nav-icon').textContent = iconMap[dir.name] || iconMap['default'];
+            template.querySelector('.nav-label').textContent = dir.name;
             navItem.appendChild(template);
             
             container.appendChild(navItem);
@@ -793,9 +807,15 @@ export class UIManager {
     }
 
     updateSidebarActiveState(path) {
-        document.querySelectorAll('.sidebar .nav-item.active').forEach(item => item.classList.remove('active'));
+        document.querySelectorAll('.sidebar .nav-item').forEach(item => {
+            item.classList.remove('active');
+            item.removeAttribute('aria-current');
+        });
         const activeItem = [...document.querySelectorAll('.sidebar .nav-item')].find(item => item.dataset.path === path);
-        if (activeItem) activeItem.classList.add('active');
+        if (activeItem) {
+            activeItem.classList.add('active');
+            activeItem.setAttribute('aria-current', 'page');
+        }
     }
 
     updateAria2cVisibility(enabled) {

--- a/static/templates/app_shell.html
+++ b/static/templates/app_shell.html
@@ -1,21 +1,40 @@
 <div class="app-container">
-    <div class="sidebar">
+    <aside class="sidebar">
         <div class="logo"><h1>Pure Mania</h1></div>
-        <div class="nav-item active" data-path="/"><i>📁</i><span>Home</span></div>
-        <div id="specific-dirs-container"></div>
-        <div class="nav-item" id="upload-status-btn" data-path="/system/uploads"><i>⇧</i><span>Uploads</span></div>
-        <div class="nav-item" id="aria2c-status-btn" data-path="/system/aria2c"><span>aria2c</span></div>
+        <nav class="file-navigation" aria-label="File manager">
+            <a href="/" class="nav-item active" data-path="/" aria-current="page">
+                <span class="nav-icon" aria-hidden="true">📁</span><span>Home</span>
+            </a>
+            <div id="specific-dirs-container"></div>
+            <a href="/system/uploads" class="nav-item" id="upload-status-btn" data-path="/system/uploads">
+                <span class="nav-icon" aria-hidden="true">⇧</span><span>Uploads</span>
+            </a>
+            <a href="/system/aria2c" class="nav-item" id="aria2c-status-btn" data-path="/system/aria2c">
+                <span class="nav-icon" aria-hidden="true">⇩</span><span>aria2c</span>
+            </a>
+        </nav>
         <div class="storage-info">
             <div class="storage-text"><span id="storage-used">0 B</span> / <span id="storage-total">0 B</span></div>
-            <div class="storage-progress"><div id="storage-progress-inner" style="width: 0%"></div></div>
+            <progress class="storage-progress" id="storage-progress" value="0" max="100" aria-label="Storage usage">0%</progress>
         </div>
-    </div>
+    </aside>
     <div class="main-content">
         <div class="header">
             <div class="breadcrumb"><span class="breadcrumb-item" data-path="/">Root</span></div>
             <div class="search-container">
-                <input type="text" class="search-input" placeholder="Search...">
-                <div class="search-options" title="Search options">⚙️</div>
+                <input
+                    type="search"
+                    class="search-input"
+                    placeholder="Search…"
+                    autocomplete="off"
+                    enterkeyhint="search"
+                    spellcheck="false"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-controls="cdCompletion"
+                    aria-expanded="false"
+                >
+                <button class="search-options" type="button" title="Search options" aria-label="Search options">⚙️</button>
             </div>
         </div>
         <div class="file-browser"></div>

--- a/static/templates/components/list_view_item.html
+++ b/static/templates/components/list_view_item.html
@@ -4,7 +4,7 @@
         <span class="file-name"></span>
     </td>
     <td class="file-size"></td>
-    <td class="file-mod-time"></td>
+    <td><time class="file-mod-time"></time></td>
     <td class="file-mime-type"></td>
     <td class="file-actions"></td>
 </template>

--- a/static/templates/components/nav_item.html
+++ b/static/templates/components/nav_item.html
@@ -1,4 +1,4 @@
 <template id="nav-item-template">
-    <i></i>
-    <span></span>
+    <span class="nav-icon" aria-hidden="true"></span>
+    <span class="nav-label"></span>
 </template>

--- a/static/templates/components/view_toggle.html
+++ b/static/templates/components/view_toggle.html
@@ -1,5 +1,14 @@
 <template id="view-toggle-template">
-    <button class="view-toggle-btn" data-view="grid">Grid</button>
-    <button class="view-toggle-btn" data-view="list">List</button>
-    <button class="view-toggle-btn" data-view="video">Video</button>
+    <label class="view-toggle-option">
+        <input class="view-toggle-input" type="radio" name="view-mode" value="grid">
+        <span>Grid</span>
+    </label>
+    <label class="view-toggle-option">
+        <input class="view-toggle-input" type="radio" name="view-mode" value="list">
+        <span>List</span>
+    </label>
+    <label class="view-toggle-option">
+        <input class="view-toggle-input" type="radio" name="view-mode" value="video">
+        <span>Video</span>
+    </label>
 </template>


### PR DESCRIPTION
## Summary

- convert the sidebar to semantic `aside`/`nav` navigation with real links
- expose the search control as a `type="search"` combobox and make search options a button
- replace the custom storage bar with a native `<progress>` element
- represent view selection as a radio group
- emit file modification timestamps as `<time datetime>`
- keep SPA navigation and active-state ARIA updates intact
- add markup contract tests for the semantic controls

## Validation

- `npm test` (23 tests passed)
- `npm run build`
- JavaScript syntax checks
- `git diff --check`