### PR TITLE
perf: add container-aware file browser rendering

### DIFF
--- a/static/css/components/file-browser.css
+++ b/static/css/components/file-browser.css
@@ -3,6 +3,7 @@
   flex: 1;
   padding: 20px;
   overflow-y: auto;
+  container: file-browser / inline-size;
 }
 
 .view-toggle {
@@ -77,6 +78,17 @@
 .file-item.selected {
   border-color: var(--accent-primary);
   background-color: rgba(0, 255, 65, 0.1);
+}
+
+.file-item:has(input[type="checkbox"]:checked) {
+  border-color: var(--accent-primary);
+  background-color: rgba(0, 255, 65, 0.1);
+}
+
+.file-grid > .file-item,
+.file-list > .file-item {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 190px;
 }
 
 .file-icon {
@@ -179,6 +191,8 @@ div.file-item:hover .file-actions {
 
 .table-view tbody tr {
   transition: background-color 0.3s ease;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 48px;
 }
 
 .table-view tbody tr:hover {
@@ -223,4 +237,32 @@ div.file-item:hover .file-actions {
 /* テキストファイル: 白 */
 .file-item[data-mime-type="text/plain"] .file-name {
     color: #ffffff;
+}
+
+@container file-browser (width < 700px) {
+  .file-browser {
+    padding: 12px;
+  }
+
+  .file-grid,
+  .file-list {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+  }
+
+  .table-view th,
+  .table-view td {
+    padding-inline: 6px;
+  }
+
+  .table-view th[data-sort="type"],
+  .table-view td:nth-child(4) {
+    display: none;
+  }
+}
+
+@container file-browser (width >= 700px) {
+  .file-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
 }

--- a/static/css/components/video-view.css
+++ b/static/css/components/video-view.css
@@ -12,6 +12,8 @@
     overflow: hidden;
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 220px;
 }
 
 .video-card:hover {
@@ -53,4 +55,12 @@
     font-size: 0.8rem;
     color: var(--text-secondary);
     margin: 0;
+}
+
+@container file-browser (width < 700px) {
+    .video-grid {
+        grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+        gap: 10px;
+        padding: 8px;
+    }
 }

--- a/static/css/masonry.css
+++ b/static/css/masonry.css
@@ -13,6 +13,8 @@
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
   cursor: pointer;
   position: relative;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
 }
 
 .masonry-item:hover {
@@ -71,4 +73,17 @@
 .masonry-item.selected {
   border-color: var(--accent-primary);
   box-shadow: 0 0 0 3px var(--accent-primary) inset;
+}
+
+.masonry-item:has(input[type="checkbox"]:checked) {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary) inset;
+}
+
+@container file-browser (width < 700px) {
+  .masonry-grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+    padding: 4px;
+  }
 }

--- a/static/js/layout-performance.test.mjs
+++ b/static/js/layout-performance.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const readStyle = relativePath => readFile(new URL(`../css/${relativePath}`, import.meta.url), 'utf8');
+
+test('file browser styles declare a named inline-size container', async () => {
+    const styles = await readStyle('components/file-browser.css');
+    assert.match(styles, /container:\s*file-browser\s*\/\s*inline-size/);
+    assert.match(styles, /@container file-browser \(width < 700px\)/);
+});
+
+test('large file collections opt into deferred rendering', async () => {
+    const [browserStyles, masonryStyles, videoStyles] = await Promise.all([
+        readStyle('components/file-browser.css'),
+        readStyle('masonry.css'),
+        readStyle('components/video-view.css')
+    ]);
+    for (const styles of [browserStyles, masonryStyles, videoStyles]) {
+        assert.match(styles, /content-visibility:\s*auto/);
+        assert.match(styles, /contain-intrinsic-size/);
+    }
+});
+
+test('selection styling supports checkbox-driven state with :has', async () => {
+    const [browserStyles, masonryStyles] = await Promise.all([
+        readStyle('components/file-browser.css'),
+        readStyle('masonry.css')
+    ]);
+    assert.match(browserStyles, /\.file-item:has\(/);
+    assert.match(masonryStyles, /\.masonry-item:has\(/);
+});


### PR DESCRIPTION
## Summary

- declare the file browser as a named inline-size container
- adapt grid, table, masonry, and video layouts to the browser's own width
- defer offscreen rendering with `content-visibility: auto`
- add intrinsic sizes for large file collections
- support checkbox-driven selection styling with `:has()`
- add CSS structure tests for the performance primitives

## Validation

- `npm test` (26 tests passed)
- `npm run build`
- `git diff --check`