### PR TITLE
refactor: define CSS cascade layers

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,20 +1,22 @@
-@import url('base/variables.css');
-@import url('base/base.css');
+@layer reset, tokens, base, layout, components, utilities, responsive;
 
-@import url('layout/header.css');
-@import url('layout/sidebar.css');
+@import url('base/variables.css') layer(tokens);
+@import url('base/base.css') layer(base);
 
-@import url('components/buttons.css');
-@import url('components/modal.css');
-@import url('components/file-browser.css');
-@import url('components/media-player.css');
-@import url('components/image-viewer.css');
-@import url('components/search.css');
-@import url('components/toast.css');
-@import url('components/editor.css');
-@import url('components/context-menu.css');
-@import url('components/progress.css');
-@import url('components/upload.css');
-@import url('components/aria2c.css');
+@import url('layout/header.css') layer(layout);
+@import url('layout/sidebar.css') layer(layout);
 
-@import url('responsive.css');
+@import url('components/buttons.css') layer(components);
+@import url('components/modal.css') layer(components);
+@import url('components/file-browser.css') layer(components);
+@import url('components/media-player.css') layer(components);
+@import url('components/image-viewer.css') layer(components);
+@import url('components/search.css') layer(components);
+@import url('components/toast.css') layer(components);
+@import url('components/editor.css') layer(components);
+@import url('components/context-menu.css') layer(components);
+@import url('components/progress.css') layer(components);
+@import url('components/upload.css') layer(components);
+@import url('components/aria2c.css') layer(components);
+
+@import url('responsive.css') layer(responsive);

--- a/static/js/css-architecture.test.mjs
+++ b/static/js/css-architecture.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const styleSheet = () => readFile(new URL('../css/style.css', import.meta.url), 'utf8');
+
+test('the main stylesheet declares an explicit cascade layer order', async () => {
+    const styles = await styleSheet();
+    assert.match(styles, /@layer reset, tokens, base, layout, components, utilities, responsive;/);
+});
+
+test('stylesheet imports are assigned to the intended cascade layers', async () => {
+    const styles = await styleSheet();
+    const imports = styles.matchAll(/@import url\('([^']+)'\) layer\(([^)]+)\);/g);
+    const assignments = Object.fromEntries([...imports].map(([, path, layer]) => [path, layer]));
+    assert.equal(assignments['base/variables.css'], 'tokens');
+    assert.equal(assignments['base/base.css'], 'base');
+    assert.equal(assignments['layout/sidebar.css'], 'layout');
+    assert.equal(assignments['components/file-browser.css'], 'components');
+    assert.equal(assignments['responsive.css'], 'responsive');
+});


### PR DESCRIPTION
## Summary

- define the project-wide cascade layer order
- assign base tokens, base styles, layout, components, and responsive imports to named layers
- add frontend tests that verify layer ordering and import assignments

## Validation

- `npm test` (28 tests passed)
- `npm run build`
- `git diff --check`