### PR TITLE
refactor: modernize logical CSS sizing

### DIFF
--- a/static/css/components/file-browser.css
+++ b/static/css/components/file-browser.css
@@ -137,8 +137,8 @@
 
 div.file-item .file-actions {
   position: absolute;
-  top: 5px;
-  right: 5px;
+  inset-block-start: 5px;
+  inset-inline-end: 5px;
   opacity: 0;
   transition: opacity 0.3s ease;
 }
@@ -155,7 +155,7 @@ div.file-item:hover .file-actions {
   height: 25px;
   border-radius: 3px;
   cursor: pointer;
-  margin-left: 5px;
+  margin-inline-start: 5px;
   font-size: 0.8rem;
 }
 

--- a/static/css/components/image-viewer.css
+++ b/static/css/components/image-viewer.css
@@ -72,11 +72,11 @@
 }
 
 .image-nav.prev {
-  left: 20px;
+  inset-inline-start: 20px;
 }
 
 .image-nav.next {
-  right: 20px;
+  inset-inline-end: 20px;
 }
 
 .image-info {
@@ -124,8 +124,8 @@
 /* ズーム機能のためのスタイル */
 .image-zoom-controls {
     position: absolute;
-    bottom: 20px;
-    right: 20px;
+    inset-block-end: 20px;
+    inset-inline-end: 20px;
     display: flex;
     gap: 10px;
     z-index: 10;
@@ -163,9 +163,8 @@
 
 .image-viewer.fullscreen .dialog-header {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline: 0;
     z-index: 100;
 }
 
@@ -175,9 +174,8 @@
 
 .image-viewer.fullscreen .image-info {
     position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    inset-block-end: 0;
+    inset-inline: 0;
     z-index: 100;
 }
 

--- a/static/css/components/media-player.css
+++ b/static/css/components/media-player.css
@@ -1,9 +1,8 @@
 /* Media Player Styles */
 .media-player {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset-block-end: 0;
+  inset-inline: 0;
   background-color: var(--bg-secondary);
   border-top: 1px solid var(--border-color);
   padding: 15px 20px;
@@ -25,7 +24,7 @@
   width: 56px;
   height: 56px;
   border-radius: 4px;
-  margin-right: 15px;
+  margin-inline-end: 15px;
   object-fit: cover;
   background-color: var(--bg-tertiary);
 }
@@ -129,7 +128,7 @@
   font-size: 1.2rem;
   cursor: pointer;
   padding: 5px;
-  margin-right: 10px;
+  margin-inline-end: 10px;
 }
 
 .volume-btn:hover {

--- a/static/css/components/search.css
+++ b/static/css/components/search.css
@@ -18,7 +18,7 @@
   border: none;
   color: var(--text-primary);
   padding: 5px;
-  width: 20rem;
+  width: clamp(12rem, 22vw, 20rem);
   outline: none;
   font-family: 'Courier New', monospace;
 }
@@ -32,7 +32,7 @@
     font-family: 'Courier New', monospace;
     cursor: pointer;
     transition: all 0.3s ease;
-    margin-left: 10px;
+    margin-inline-start: 10px;
 }
 
 #search-scope:hover {
@@ -48,11 +48,12 @@
 
 .search-options {
   border: 0;
-  padding: 2px 0 2px 10px;
+  padding-block: 2px;
+  padding-inline-start: 10px;
   background: transparent;
   display: flex;
   align-items: center;
-  margin-left: 10px;
+  margin-inline-start: 10px;
   color: var(--text-secondary);
   cursor: pointer;
 }

--- a/static/css/layout/sidebar.css
+++ b/static/css/layout/sidebar.css
@@ -2,7 +2,7 @@
 .sidebar {
   width: 250px;
   background-color: var(--bg-secondary);
-  border-right: 1px solid var(--border-color);
+  border-inline-end: 1px solid var(--border-color);
   padding: 20px 0;
   display: flex;
   flex-direction: column;
@@ -44,7 +44,7 @@
 
 .nav-item.active {
   background-color: var(--bg-tertiary);
-  border-left: 3px solid var(--accent-primary);
+  border-inline-start: 3px solid var(--accent-primary);
   color: var(--accent-primary);
 }
 

--- a/static/css/masonry.css
+++ b/static/css/masonry.css
@@ -37,9 +37,8 @@
   background: rgba(0, 0, 0, 0.65); /* 背景を暗めにして文字を読みやすく */
   backdrop-filter: blur(4px); /* 半透明時にぼかしを追加して見やすさUP */
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset-block-end: 0;
+  inset-inline: 0;
   transform: translateY(100%);
   transition: transform 0.3s ease;
 }
@@ -51,7 +50,7 @@
 .masonry-name {
   font-size: 0.9rem;
   font-weight: 600; /* 目立たせる */
-  margin-bottom: 6px;
+  margin-block-end: 6px;
   color: var(--text-primary); /* 読みやすい文字色 */
   white-space: nowrap;
   overflow: hidden;

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -69,11 +69,11 @@
     }
     
     .image-nav.prev {
-        left: 10px;
+        inset-inline-start: 10px;
     }
     
     .image-nav.next {
-        right: 10px;
+        inset-inline-end: 10px;
     }
     
     .image-info {
@@ -92,7 +92,7 @@
   
   .sidebar {
     width: 100%;
-    border-right: none;
+    border-inline-end: none;
     border-bottom: 1px solid var(--border-color);
   }
   
@@ -199,9 +199,9 @@
   }
 
   .editor-textarea {
-    min-height: 40rem;
-    min-width: 20rem;
-    font-size: 10px;
+    min-height: clamp(24rem, 70vh, 40rem);
+    min-width: clamp(16rem, 35vw, 20rem);
+    font-size: clamp(12px, 1vw + 9px, 15px);
   }
 
   .toolbar {

--- a/static/js/css-logical-sizing.test.mjs
+++ b/static/js/css-logical-sizing.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const readStyle = relativePath => readFile(new URL(`../css/${relativePath}`, import.meta.url), 'utf8');
+
+test('frequently mirrored UI edges use logical properties', async () => {
+    const styles = await Promise.all([
+        readStyle('layout/sidebar.css'),
+        readStyle('components/file-browser.css'),
+        readStyle('components/image-viewer.css'),
+        readStyle('components/media-player.css'),
+        readStyle('masonry.css')
+    ]);
+    const combined = styles.join('\n');
+    assert.match(combined, /border-inline-end/);
+    assert.match(combined, /inset-inline-end/);
+    assert.match(combined, /inset-inline-start/);
+    assert.match(combined, /margin-inline-end/);
+});
+
+test('responsive control sizes use clamp instead of fixed mobile jumps', async () => {
+    const styles = await Promise.all([
+        readStyle('components/search.css'),
+        readStyle('responsive.css')
+    ]);
+    const combined = styles.join('\n');
+    assert.match(combined, /width:\s*clamp\(/);
+    assert.match(combined, /font-size:\s*clamp\(/);
+    assert.match(combined, /min-height:\s*clamp\(/);
+});


### PR DESCRIPTION
## Summary

- replace mirrored physical edge properties with logical CSS equivalents
- add fluid `clamp()` sizing for search and editor controls
- preserve responsive behavior while improving RTL readiness
- add CSS contract tests for logical properties and fluid sizing

## Validation

- `npm test` (30 tests passed)
- `npm run build`
- `git diff --check`