### PR TITLE
refactor: organize component CSS with nesting

### DIFF
--- a/static/css/components/context-menu.css
+++ b/static/css/components/context-menu.css
@@ -10,27 +10,27 @@
   max-width: min(20rem, calc(100vw - 1rem));
   margin: 0;
   padding: 4px;
-}
 
-.context-menu-item {
-  display: block;
-  width: 100%;
-  padding: 10px 12px;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  text-align: start;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
+  & .context-menu-item {
+    display: block;
+    width: 100%;
+    padding: 10px 12px;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    text-align: start;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
 
-.context-menu-item:hover {
-  background-color: var(--accent-primary);
-  color: var(--bg-primary);
-}
+    &:hover {
+      background-color: var(--accent-primary);
+      color: var(--bg-primary);
+    }
+  }
 
-.context-menu-divider {
-  height: 1px;
-  background-color: var(--border-color);
-  margin-block: 5px;
+  & .context-menu-divider {
+    height: 1px;
+    background-color: var(--border-color);
+    margin-block: 5px;
+  }
 }

--- a/static/css/components/modal.css
+++ b/static/css/components/modal.css
@@ -220,39 +220,39 @@ dialog.dialog-overlay::backdrop {
         "name controls"
         "status status"
         "progress progress";
-}
 
-.download-name {
-    grid-area: name;
-    font-weight: bold;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
+    .download-name {
+        grid-area: name;
+        font-weight: bold;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 
-.download-status {
-    grid-area: status;
-    font-size: 0.8em;
-    color: var(--text-secondary);
-    display: flex;
-    justify-content: space-between;
-}
+    .download-status {
+        grid-area: status;
+        font-size: 0.8em;
+        color: var(--text-secondary);
+        display: flex;
+        justify-content: space-between;
+    }
 
-.download-item .ui-progress {
-    grid-area: progress;
-    height: 10px;
-}
+    .ui-progress {
+        grid-area: progress;
+        height: 10px;
 
-.download-item .ui-progress__fill {
-    transition: width 0.3s ease;
-}
+        .ui-progress__fill {
+            transition: width 0.3s ease;
+        }
+    }
 
-.download-controls {
-    grid-area: controls;
-    display: flex;
-    gap: 5px;
-}
+    .download-controls {
+        grid-area: controls;
+        display: flex;
+        gap: 5px;
 
-.download-controls .btn {
-    padding: 2px 6px;
+        .btn {
+            padding: 2px 6px;
+        }
+    }
 }

--- a/static/js/css-nesting.test.mjs
+++ b/static/js/css-nesting.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const readStyle = relativePath => readFile(new URL(`../css/${relativePath}`, import.meta.url), 'utf8');
+
+test('context menu styles use native CSS nesting for actions and hover state', async () => {
+    const styles = await readStyle('components/context-menu.css');
+    assert.match(styles, /&\s+\.context-menu-item\s*\{/);
+    assert.match(styles, /&\s*:hover\s*\{/);
+});
+
+test('download item styles keep related child rules inside their component', async () => {
+    const styles = await readStyle('components/modal.css');
+    const downloadItem = styles.match(/\.download-item\s*\{[\s\S]*?\n\}/)?.[0] || '';
+    assert.match(downloadItem, /\.download-name/);
+    assert.match(downloadItem, /\.download-controls/);
+    assert.match(downloadItem, /\.ui-progress__fill/);
+});


### PR DESCRIPTION
## Summary

- nest Popover-ready context-menu item and hover rules under their component
- nest Aria2c download item child styles under the download component
- add CSS contract tests for native nesting syntax
- validate nested CSS with esbuild

## Validation

- `npm test` (32 tests passed)
- `npm run build`
- esbuild CSS syntax checks
- `git diff --check`