### PR TITLE
refactor: use native progress for transfers

### DIFF
--- a/static/css/components/aria2c.css
+++ b/static/css/components/aria2c.css
@@ -54,21 +54,16 @@
 
 .aria2c-table .ui-progress {
     height: 20px;
-}
-
-.aria2c-table .ui-progress__fill {
-    transition: width 0.3s ease-in-out;
+    display: inline-block;
+    width: min(100%, 220px);
+    vertical-align: middle;
 }
 
 .aria2c-table .progress-text {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: var(--text-primary);
+    margin-inline-start: 6px;
+    color: var(--text-secondary);
     font-size: 0.8em;
     font-weight: bold;
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
 }
 
 .aria2c-table .actions {
@@ -111,7 +106,7 @@
 }
 .upload-jobs-table .file-size { width: 10%; white-space: nowrap; }
 .upload-jobs-table .upload-progress-cell { width: 18%; min-width: 150px; }
-.upload-jobs-table .upload-progress-cell .ui-progress { position: relative; min-width: 140px; }
+.upload-jobs-table .upload-progress-cell .ui-progress { min-width: 140px; }
 .upload-jobs-table .upload-destination { max-width: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .upload-jobs-table .actions {
     min-width: 210px;

--- a/static/css/components/progress.css
+++ b/static/css/components/progress.css
@@ -86,6 +86,27 @@
     position: relative;
 }
 
+progress.ui-progress {
+    appearance: none;
+    color: var(--accent-primary);
+}
+
+progress.ui-progress::-webkit-progress-bar {
+    background-color: var(--bg-tertiary);
+    border-radius: 4px;
+}
+
+progress.ui-progress::-webkit-progress-value {
+    background-color: var(--accent-primary);
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+progress.ui-progress::-moz-progress-bar {
+    background-color: var(--accent-primary);
+    border-radius: 4px;
+}
+
 .ui-progress__fill {
     height: 100%;
     background-color: var(--accent-primary);

--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pure Mania</title>
-    <link rel="stylesheet" href="/static/css/style.css?v=R2CI4ZAK">
-    <link rel="stylesheet" href="/static/css/masonry.css?v=R2CI4ZAK">
-    <link rel="stylesheet" href="/static/css/components/video-view.css?v=R2CI4ZAK">
+    <link rel="stylesheet" href="/static/css/style.css?v=5UJI2L4R">
+    <link rel="stylesheet" href="/static/css/masonry.css?v=5UJI2L4R">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?v=5UJI2L4R">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>
@@ -16,10 +16,10 @@
     <script type="module">
         const root = document.getElementById('app-root');
         try {
-            const response = await fetch('/static/templates/app_shell.html?v=R2CI4ZAK');
+            const response = await fetch('/static/templates/app_shell.html?v=5UJI2L4R');
             if (!response.ok) throw new Error(`App shell request failed (${response.status})`);
             root.innerHTML = await response.text();
-            await import('/static/dist/app-R2CI4ZAK.js');
+            await import('/static/dist/app-5UJI2L4R.js');
         } catch (error) {
             console.error('Failed to load the application shell', error);
             root.textContent = 'Failed to load the application. Please reload.';

--- a/static/js/aria2c-page.js
+++ b/static/js/aria2c-page.js
@@ -172,7 +172,9 @@ export class Aria2cPageHandler {
         template.querySelector('.file-name').textContent = fileName;
         template.querySelector('.file-name').title = fileName;
         template.querySelector('.file-size').textContent = this.fileManager.ui.formatFileSize(totalLength);
-        template.querySelector('.ui-progress__fill').style.width = `${progress.toFixed(2)}%`;
+        const progressBar = template.querySelector('.ui-progress');
+        progressBar.value = progress;
+        progressBar.textContent = `${progress.toFixed(2)}%`;
         template.querySelector('.progress-text').textContent = `${progress.toFixed(2)}%`;
         template.querySelector('.status').textContent = item.status;
         template.querySelector('.speed').textContent = `${this.fileManager.ui.formatFileSize(downloadSpeed)}/s`;

--- a/static/js/progress-markup.test.mjs
+++ b/static/js/progress-markup.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const template = relativePath => readFile(new URL(`../templates/components/${relativePath}`, import.meta.url), 'utf8');
+
+test('transfer rows expose native progress elements', async () => {
+    const [uploadRow, aria2cRow] = await Promise.all([
+        template('upload_page_row.html'),
+        template('aria2c_table_row.html')
+    ]);
+    for (const markup of [uploadRow, aria2cRow]) {
+        assert.match(markup, /<progress class="ui-progress"/);
+        assert.match(markup, /max="100"/);
+        assert.doesNotMatch(markup, /ui-progress__fill/);
+    }
+});
+
+test('the upload overlay uses a native progress element', async () => {
+    const markup = await template('progress_overlay.html');
+    assert.match(markup, /<progress class="ui-progress"/);
+    assert.doesNotMatch(markup, /role="progressbar"/);
+    assert.doesNotMatch(markup, /ui-progress__fill/);
+});

--- a/static/js/progress.js
+++ b/static/js/progress.js
@@ -140,7 +140,6 @@ export class ProgressManager {
 
         const elements = {
             current: this.progressOverlay.querySelector('.progress-current'),
-            barFill: this.progressOverlay.querySelector('.ui-progress__fill'),
             progressBar: this.progressOverlay.querySelector('.ui-progress'),
             percentage: this.progressOverlay.querySelector('.progress-percentage'),
             stats: this.progressOverlay.querySelector('.progress-stats'),
@@ -148,8 +147,10 @@ export class ProgressManager {
         };
 
         if (elements.current) elements.current.textContent = currentFile;
-        if (elements.barFill) elements.barFill.style.width = percentageText;
-        if (elements.progressBar) elements.progressBar.setAttribute('aria-valuenow', String(Math.round(safePercentage)));
+        if (elements.progressBar) {
+            elements.progressBar.value = safePercentage;
+            elements.progressBar.textContent = percentageText;
+        }
         if (elements.percentage) elements.percentage.textContent = percentageText;
         if (elements.stats) elements.stats.textContent = statsText;
         if (elements.status && status) elements.status.textContent = status;

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -104,7 +104,9 @@ export class UploadPageHandler {
         row.querySelector('.file-name').textContent = name;
         row.querySelector('.file-name').title = job.relativePath;
         row.querySelector('.file-size').textContent = this.app.ui.formatFileSize(total);
-        row.querySelector('.ui-progress__fill').style.width = `${progress.toFixed(2)}%`;
+        const progressBar = row.querySelector('.ui-progress');
+        progressBar.value = progress;
+        progressBar.textContent = `${progress.toFixed(2)}%`;
         row.querySelector('.progress-text').textContent = `${progress.toFixed(2)}%`;
         row.querySelector('.status').textContent = job.state;
         row.querySelector('.upload-destination').textContent = job.destination;

--- a/static/templates/components/aria2c_table_row.html
+++ b/static/templates/components/aria2c_table_row.html
@@ -2,10 +2,8 @@
     <td class="file-name"></td>
     <td class="file-size"></td>
     <td>
-        <div class="ui-progress">
-            <div class="ui-progress__fill"></div>
-            <span class="progress-text"></span>
-        </div>
+        <progress class="ui-progress" max="100" value="0" aria-label="Download progress">0%</progress>
+        <span class="progress-text">0%</span>
     </td>
     <td class="status"></td>
     <td class="speed"></td>

--- a/static/templates/components/progress_overlay.html
+++ b/static/templates/components/progress_overlay.html
@@ -10,9 +10,7 @@
         <div class="progress-info">
             <span class="progress-current">Preparing files...</span>
         </div>
-        <div class="ui-progress" role="progressbar" aria-label="Upload progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-            <div class="ui-progress__fill"></div>
-        </div>
+        <progress class="ui-progress" max="100" value="0" aria-label="Upload progress">0%</progress>
         <div class="progress-details">
             <span class="progress-percentage">0%</span>
             <span class="progress-stats">0 files processed</span>

--- a/static/templates/components/upload_page_row.html
+++ b/static/templates/components/upload_page_row.html
@@ -3,10 +3,8 @@
     <td class="file-name"></td>
     <td class="file-size"></td>
     <td class="upload-progress-cell">
-        <div class="ui-progress">
-            <div class="ui-progress__fill"></div>
-            <span class="progress-text"></span>
-        </div>
+        <progress class="ui-progress" max="100" value="0" aria-label="Upload progress">0%</progress>
+        <span class="progress-text">0%</span>
     </td>
     <td class="status"></td>
     <td class="upload-destination"></td>


### PR DESCRIPTION
## Summary

- replace upload and aria2c transfer bars with native `<progress>` elements
- replace the upload progress overlay's custom progressbar with native progress semantics
- update transfer renderers to assign `progress.value` and fallback text
- keep the media player's interactive seek control as a slider
- add markup contract tests for transfer progress elements

## Validation

- `npm test` (34 tests passed)
- `npm run build`
- JavaScript syntax checks
- esbuild CSS syntax checks
- `git diff --check`