### PR TITLE
fix: preserve TTL cache size invariant

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -72,6 +72,13 @@ func Set(c *types.TTLCache, key string, data interface{}, size int64, ttl time.D
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 
+	// Entries larger than the cache cannot satisfy the cache's size
+	// invariant. Negative sizes would corrupt the accounting in the other
+	// direction, so reject both cases before evicting an existing value.
+	if size < 0 || size > c.MaxSize {
+		return
+	}
+
 	if _, exists := c.Entries[key]; exists {
 		evict(c, key)
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -26,3 +26,38 @@ func TestSetReplacementKeepsSizeAccounting(t *testing.T) {
 		t.Fatal("expected the replaced key to be evicted when the cache limit is exceeded")
 	}
 }
+
+func TestSetRejectsInvalidSizes(t *testing.T) {
+	c := NewTTLCache(10, 10)
+
+	Set(c, "valid", "value", 4, time.Hour)
+	Set(c, "oversized", "value", 11, time.Hour)
+	Set(c, "negative", "value", -1, time.Hour)
+
+	entries, size := Stats(c)
+	if entries != 1 || size != 4 {
+		t.Fatalf("expected one 4-byte entry, got entries=%d size=%d", entries, size)
+	}
+	if _, ok := Get(c, "valid"); !ok {
+		t.Fatal("expected valid entry to remain cached")
+	}
+}
+
+func TestSetRejectsInvalidReplacementWithoutRemovingExistingEntry(t *testing.T) {
+	c := NewTTLCache(10, 10)
+
+	Set(c, "key", "original", 6, time.Hour)
+	Set(c, "key", "oversized replacement", 11, time.Hour)
+
+	entry, ok := Get(c, "key")
+	if !ok {
+		t.Fatal("expected original entry to remain cached")
+	}
+	if entry != "original" {
+		t.Fatalf("expected original value, got %v", entry)
+	}
+	_, size := Stats(c)
+	if size != 6 {
+		t.Fatalf("expected size accounting to remain 6, got %d", size)
+	}
+}


### PR DESCRIPTION
## Summary
- reject negative and oversized cache entries before replacing existing values
- preserve `0 <= CurSize <= MaxSize` accounting for invalid Set calls
- add regression tests for invalid inserts and replacements

## Tests
- `go test ./...`
- `git diff --check`