### PR TITLE
fix: separate upload concurrency capacity telemetry

### DIFF
--- a/handlers/resumable_upload_handlers.go
+++ b/handlers/resumable_upload_handlers.go
@@ -310,11 +310,12 @@ func (h *Handler) UploadChunk(w http.ResponseWriter, r *http.Request) {
 	// network saturation without coupling correctness to a specific algorithm.
 	w.Header().Set("Upload-Queue-Delay", strconv.FormatInt(queueDelay.Milliseconds(), 10))
 	w.Header().Set("Upload-Write-Time", strconv.FormatInt(writeTime.Milliseconds(), 10))
-	available := cap(h.uploadGate) - len(h.uploadGate) + 1
-	if available < 1 {
-		available = 1
-	}
-	w.Header().Set("Upload-Recommend-Concurrency", strconv.Itoa(available))
+	// Report the gate's fixed capacity and the occupancy at this response's
+	// write point separately. The previous recommendation header mixed the two
+	// values, causing clients to mistake instantaneous free capacity for a
+	// server-wide concurrency limit.
+	w.Header().Set("Upload-Concurrency-Capacity", strconv.Itoa(cap(h.uploadGate)))
+	w.Header().Set("Upload-Concurrency-Active", strconv.Itoa(len(h.uploadGate)))
 	session.UploadedBytes += written
 	if err := h.writeUploadSession(session); err != nil {
 		h.respondError(w, "Cannot persist upload progress", http.StatusInternalServerError)

--- a/handlers/resumable_upload_handlers_test.go
+++ b/handlers/resumable_upload_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"puremania/types"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -56,6 +57,17 @@ func TestUploadChunkOversizeRetryCannotLeaveTail(t *testing.T) {
 	h.UploadChunk(ok, retry)
 	if ok.Code != http.StatusOK {
 		t.Fatalf("retry status = %d, body = %s", ok.Code, ok.Body.String())
+	}
+	capacity, err := strconv.Atoi(ok.Header().Get("Upload-Concurrency-Capacity"))
+	if err != nil || capacity < 1 {
+		t.Fatalf("invalid upload concurrency capacity header: %q", ok.Header().Get("Upload-Concurrency-Capacity"))
+	}
+	active, err := strconv.Atoi(ok.Header().Get("Upload-Concurrency-Active"))
+	if err != nil || active < 1 || active > capacity {
+		t.Fatalf("invalid upload concurrency active header: %q (capacity=%d)", ok.Header().Get("Upload-Concurrency-Active"), capacity)
+	}
+	if legacy := ok.Header().Get("Upload-Recommend-Concurrency"); legacy != "" {
+		t.Fatalf("legacy ambiguous concurrency header is still present: %q", legacy)
 	}
 
 	complete := httptest.NewRecorder()

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -109,10 +109,13 @@ class AdaptiveUploadController {
         this.congested = false;
     }
 
-    record({ bytes, elapsed, queueDelay = 0, writeTime = 0, recommendation }) {
+    record({ bytes, elapsed, queueDelay = 0, writeTime = 0, capacity = 0, active = 0 }) {
         const speed = elapsed > 0 ? bytes / elapsed * 1000 : 0;
         this.speedEWMA = this.speedEWMA ? this.speedEWMA * 0.75 + speed * 0.25 : speed;
-        if (recommendation > 0) this.serverCap = Math.max(MIN_CONCURRENT_FILES, Math.min(MAX_CONCURRENT_FILES, recommendation));
+        if (capacity > 0) {
+            this.serverCap = Math.max(1, Math.min(MAX_CONCURRENT_FILES, capacity));
+            this.serverActive = Math.max(0, active);
+        }
         // Queueing longer than the write itself is a server-side congestion signal.
         this.congested ||= queueDelay > 100 && queueDelay > writeTime;
     }
@@ -126,9 +129,13 @@ class AdaptiveUploadController {
         if (now - this.lastDecisionAt < 1500) return this.target;
         const heap = performance.memory;
         const memoryPressure = heap && heap.jsHeapSizeLimit > 0 && heap.usedJSHeapSize / heap.jsHeapSizeLimit > 0.80;
+        const ceiling = Math.min(MAX_CONCURRENT_FILES, this.serverCap);
+        const floor = Math.min(MIN_CONCURRENT_FILES, ceiling);
         if (this.congested || memoryPressure) {
-            this.target = Math.max(MIN_CONCURRENT_FILES, Math.floor(this.target * 0.7));
-        } else if (this.target < Math.min(MAX_CONCURRENT_FILES, this.serverCap) &&
+            this.target = Math.max(floor, Math.floor(this.target * 0.7));
+        } else if (this.target > ceiling) {
+            this.target = ceiling;
+        } else if (this.target < ceiling &&
                    (this.lastDecisionSpeed === 0 || this.speedEWMA >= this.lastDecisionSpeed * 1.07)) {
             this.target++;
         }
@@ -170,6 +177,8 @@ class UploadSessionStore {
         });
     }
 }
+
+export { AdaptiveUploadController };
 
 export class Uploader {
     constructor(app) {
@@ -454,7 +463,8 @@ export class Uploader {
                         elapsed: performance.now() - startedAt,
                         queueDelay: Number(xhr.getResponseHeader('Upload-Queue-Delay')) || 0,
                         writeTime: Number(xhr.getResponseHeader('Upload-Write-Time')) || 0,
-                        recommendation: Number(xhr.getResponseHeader('Upload-Recommend-Concurrency')) || 0
+                        capacity: Number(xhr.getResponseHeader('Upload-Concurrency-Capacity')) || 0,
+                        active: Number(xhr.getResponseHeader('Upload-Concurrency-Active')) || 0
                     });
                     try {
                         const result = JSON.parse(xhr.responseText);

--- a/static/js/uploader.test.mjs
+++ b/static/js/uploader.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import test from 'node:test';
-import { Uploader } from './uploader.js';
+import { AdaptiveUploadController, Uploader } from './uploader.js';
 
 function mockFile(contents) {
     const bytes = new TextEncoder().encode(contents);
@@ -28,4 +28,15 @@ test('file fingerprints work without Web Crypto', async () => {
     } finally {
         Object.defineProperty(globalThis, 'crypto', cryptoDescriptor);
     }
+});
+
+test('server concurrency capacity of one is not raised to the client minimum', () => {
+    const controller = new AdaptiveUploadController();
+    controller.target = 2;
+    controller.record({ bytes: 1, elapsed: 1, capacity: 1, active: 1 });
+    controller.lastDecisionAt = performance.now() - 2000;
+
+    assert.equal(controller.adjust(), 1);
+    assert.equal(controller.serverCap, 1);
+    assert.equal(controller.serverActive, 1);
 });


### PR DESCRIPTION
## Summary
- replace ambiguous `C-N+1` upload recommendation with explicit capacity and active-count headers
- make the browser uploader honor a server capacity of one
- add Go and frontend regression coverage for the new contract

## Tests
- `go test ./...`
- `npm test`
- `git diff --check`