### PR TITLE
fix: block cross-site request forgery on the file API

### DIFF
--- a/csrf_protection.go
+++ b/csrf_protection.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// csrfProtectionMiddleware blocks cross-site state-changing requests. Pure Mania
+// exposes an unauthenticated API by design, so a malicious website can otherwise
+// drive a victim's browser into performing file operations (delete, move, save,
+// extract) against a reachable instance using "simple" cross-origin requests
+// that never trigger a CORS preflight (e.g. Content-Type: text/plain).
+//
+// Two independent signals are enforced:
+//
+//   - Sec-Fetch-Site is sent by every modern browser and is set to "cross-site"
+//     for cross-origin requests. Non-browser clients (curl, scripts) omit the
+//     header and remain allowed.
+//   - JSON-body endpoints additionally require an application/json content type,
+//     closing the gap for the remaining content types that qualify as "simple
+//     requests" in older browsers.
+func csrfProtectionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isStateChangingMethod(r.Method) {
+			if strings.EqualFold(r.Header.Get("Sec-Fetch-Site"), "cross-site") {
+				http.Error(w, "Cross-site requests are not allowed", http.StatusForbidden)
+				return
+			}
+			if !strings.HasPrefix(r.URL.Path, "/api/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Streaming endpoints carry non-JSON bodies (multipart form data and
+			// binary upload chunks) and are not CSRF targets carrying JSON. DELETE
+			// requests are bodyless and only protected by the Sec-Fetch-Site check.
+			if r.Method != http.MethodPost && r.Method != http.MethodPut {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if r.URL.Path == "/api/files/upload" || strings.HasSuffix(r.URL.Path, "/chunks") {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if !hasJSONContentType(r) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnsupportedMediaType)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"success": false,
+					"message": "Content-Type must be application/json",
+				})
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isStateChangingMethod(method string) bool {
+	return method == http.MethodPost || method == http.MethodPut || method == http.MethodDelete
+}
+
+func hasJSONContentType(r *http.Request) bool {
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	mediaType = strings.ToLower(mediaType)
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}

--- a/csrf_protection_test.go
+++ b/csrf_protection_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newCSRFTestHandler() http.Handler {
+	probe := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return csrfProtectionMiddleware(probe)
+}
+
+func TestCSRFRejectsCrossSiteFetchSite(t *testing.T) {
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/files/delete", strings.NewReader(`{"paths":["/"]}`))
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	newCSRFTestHandler().ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusForbidden)
+	}
+}
+
+func TestCSRFRejectsTextPlainJSONBody(t *testing.T) {
+	// A cross-origin "simple request" can carry a JSON payload with
+	// Content-Type: text/plain and never trigger a CORS preflight.
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/files/delete", strings.NewReader(`{"paths":["/"]}`))
+	req.Header.Set("Content-Type", "text/plain")
+	newCSRFTestHandler().ServeHTTP(res, req)
+	if res.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestCSRFAllowsJSONContentType(t *testing.T) {
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/files/delete", strings.NewReader(`{"paths":["/"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	newCSRFTestHandler().ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+}
+
+func TestCSRFAllowsVendorJSONContentType(t *testing.T) {
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/files/delete", strings.NewReader(`{"paths":["/"]}`))
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	newCSRFTestHandler().ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+}
+
+func TestCSRFAllowsStreamingEndpointsWithoutJSON(t *testing.T) {
+	for _, tc := range []struct {
+		method, path, contentType string
+	}{
+		{http.MethodPut, "/api/files/upload-sessions/abc/chunks", "application/octet-stream"},
+		{http.MethodPost, "/api/files/upload", "multipart/form-data; boundary=x"},
+	} {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		req.Header.Set("Content-Type", tc.contentType)
+		newCSRFTestHandler().ServeHTTP(res, req)
+		if res.Code != http.StatusOK {
+			t.Errorf("%s %s status = %d, want %d", tc.method, tc.path, res.Code, http.StatusOK)
+		}
+	}
+}
+
+func TestCSRFAllowsBodylessDelete(t *testing.T) {
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/files/upload-sessions/abcdef", nil)
+	newCSRFTestHandler().ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+}
+
+func TestCSRFAllowsReadOnlyMethods(t *testing.T) {
+	res := httptest.NewRecorder()
+	newCSRFTestHandler().ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/api/files", nil))
+	if res.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", res.Code, http.StatusOK)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Handler:           securityHeadersMiddleware(requestBodyLimitMiddleware(responseCompressionMiddleware(r))),
+		Handler:           securityHeadersMiddleware(csrfProtectionMiddleware(requestBodyLimitMiddleware(responseCompressionMiddleware(r)))),
 		Addr:              fmt.Sprintf(":%d", cfg.Port),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       10 * time.Minute,


### PR DESCRIPTION
## Security: block cross-site request forgery on the file API

### Problem
The API is unauthenticated by design and exposes destructive file operations (`/api/files/delete`, `/save`, `/move`, `/extract`, ...). I confirmed that a JSON body sent with `Content-Type: text/plain` (a CORS "simple request") is accepted and executes — meaning any website a victim visits can silently delete/overwrite files on a reachable Pure Mania instance from the victim's browser, with no preflight.

Reproduction:
```bash
curl -X POST http://<host>:8844/api/files/delete \
  -H 'Content-Type: text/plain' --data '{"paths":["/victim.txt"]}'   # 200, file deleted
```

### Fix
New `csrfProtectionMiddleware`, wired into the handler chain:
- Rejects requests the browser signals as cross-site (`Sec-Fetch-Site: cross-site` → 403). Non-browser clients (curl) omit the header and are unaffected.
- Requires `application/json` (or `+json`) on JSON-body POST/PUT endpoints (→ 415), closing the gap for older browsers.
- Exempts streaming endpoints (multipart `/api/files/upload`, binary `/chunks`) and bodyless DELETE.

Frontend already sends `Content-Type: application/json`, so no UI change is needed.

### Verification
- New unit tests covering 415/403/allow paths.
- End-to-end: `text/plain` delete now returns 415, `Sec-Fetch-Site: cross-site` returns 403, legitimate `application/json` requests still succeed.
- `go test -race ./...` passes.
