### PR TITLE
fix: sandbox user content to prevent stored XSS

### DIFF
--- a/handlers/content_security_test.go
+++ b/handlers/content_security_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"puremania/types"
+)
+
+func newContentTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	return NewHandler(&types.Config{StorageDir: t.TempDir()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDownloadSandboxesActiveContent(t *testing.T) {
+	h := newContentTestHandler(t)
+	writeTestFile(t, filepath.Join(h.config.StorageDir, "evil.svg"), `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`)
+
+	res := httptest.NewRecorder()
+	h.DownloadFile(res, httptest.NewRequest(http.MethodGet, "/api/files/download?path=/evil.svg", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+	if got := res.Header().Get("Content-Security-Policy"); got != "sandbox" {
+		t.Fatalf("Content-Security-Policy = %q, want sandbox", got)
+	}
+	if got := res.Header().Get("Content-Type"); got != "image/svg+xml" {
+		t.Fatalf("Content-Type = %q, want image/svg+xml", got)
+	}
+}
+
+func TestDownloadSandboxesMediaContent(t *testing.T) {
+	h := newContentTestHandler(t)
+	writeTestFile(t, filepath.Join(h.config.StorageDir, "clip.mp4"), "not really a video")
+
+	res := httptest.NewRecorder()
+	h.DownloadFile(res, httptest.NewRequest(http.MethodGet, "/api/files/download?path=/clip.mp4", nil))
+
+	if got := res.Header().Get("Content-Security-Policy"); got != "sandbox" {
+		t.Fatalf("Content-Security-Policy = %q, want sandbox", got)
+	}
+}
+
+func TestGetFileContentSandboxesImageContent(t *testing.T) {
+	h := newContentTestHandler(t)
+	writeTestFile(t, filepath.Join(h.config.StorageDir, "evil.svg"), `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`)
+
+	res := httptest.NewRecorder()
+	h.GetFileContent(res, httptest.NewRequest(http.MethodGet, "/api/files/content?path=/evil.svg", nil))
+
+	if got := res.Header().Get("Content-Security-Policy"); got != "sandbox" {
+		t.Fatalf("Content-Security-Policy = %q, want sandbox", got)
+	}
+}

--- a/handlers/file_handlers.go
+++ b/handlers/file_handlers.go
@@ -899,6 +899,11 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 	filename := filepath.Base(path)
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", contentDisposition(filename))
+	// User-controlled files may contain active content (SVG scripts, HTML, XML).
+	// Sandboxing the document makes it an opaque, script-free origin even when a
+	// browser navigates to the file directly, preventing stored XSS in the
+	// application's origin. The header is ignored by <img>/<video> embedding.
+	w.Header().Add("Content-Security-Policy", "sandbox")
 
 	// http.ServeContentを使用してsendfile最適化とRange/If-Modified-Since自動処理
 	http.ServeContent(w, r, filename, stat.ModTime(), file)
@@ -952,6 +957,9 @@ func (h *Handler) GetFileContent(w http.ResponseWriter, r *http.Request) {
 	// 画像ファイルの場合はhttp.ServeFileで最適化
 	if mimeType != "" && strings.HasPrefix(mimeType, "image/") {
 		w.Header().Set("Cache-Control", "max-age=3600")
+		// image/svg+xml is served here too; sandbox the document so inline
+		// scripts can never run in the application's origin.
+		w.Header().Add("Content-Security-Policy", "sandbox")
 		http.ServeContent(w, r, filepath.Base(path), stat.ModTime(), file)
 		return
 	}


### PR DESCRIPTION
## Security: prevent stored XSS via inline-served user content

### Problem
`/api/files/download` (and the image branch of `/api/files/content`) serves user files inline with their content type and a `Content-Disposition: inline`. An uploaded SVG/HTML/XML file navigated to directly is therefore rendered as an active document in the application's origin — and the global CSP permits `script-src 'unsafe-inline'`, so its `<script>` executes.

Reproduction (confirmed against a running instance):
```bash
printf '<svg xmlns="http://www.w3.org/2000/svg"><script>fetch("/api/files/download?path=/victim.txt")</script></svg>' > storage/evil.svg
# GET /api/files/download?path=/evil.svg  ->
#   Content-Type: image/svg+xml
#   Content-Disposition: inline
#   Content-Security-Policy: ... script-src 'self' 'unsafe-inline' ...
```

### Fix
Add a `Content-Security-Policy: sandbox` header to user-content responses on both endpoints. A sandboxed document becomes an opaque, script-free, form-free origin, so active content can never execute in the app origin. The header is ignored by `<img>`/`<video>` embedding, so thumbnails, media playback, and inline preview all keep working. The global CSP header is preserved (multiple CSP headers are combined).

### Verification
- New unit tests assert the sandbox header on SVG downloads, media downloads, and the image content endpoint.
- End-to-end confirmed both `default-src ...` and `sandbox` CSP headers are sent.
- `go test -race ./...` passes.
