### PR TITLE
fix: bind aria2c RPC to loopback only

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func startAria2cDaemon(logger *slog.Logger) (rpcURL string, rpcToken string, err
 	cmd := exec.Command(
 		"aria2c",
 		"--enable-rpc",
-		"--rpc-listen-all=true",
+		"--rpc-listen-all=false",
 		"--rpc-listen-port", rpcPort,
 		"--rpc-secret", token,
 		"--no-conf",


### PR DESCRIPTION
## Security: bind aria2c JSON-RPC to loopback only

### Problem
When the aria2c integration is enabled, the daemon is started with `--rpc-listen-all=true`, exposing the JSON-RPC endpoint (port 6800) on every network interface. Pure Mania only ever connects via `http://localhost:6800/jsonrpc` (the daemon is a child process in the same container/host), so listening on all interfaces only widens the attack surface with no functional benefit.

### Fix
Start aria2c with `--rpc-listen-all=false` (the default), restricting the RPC listener to the loopback interface. The `--rpc-secret` token remains in place; this is defense-in-depth that also avoids exposing the port to LAN neighbors or other containers.

### Verification
- `go build`/`go vet` pass.
- Flag change only; no functional impact on the RPC URL used by the app.
