### PR TITLE
feat: sync upload changes across tabs

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pure Mania</title>
-    <link rel="stylesheet" href="/static/css/style.css?v=642UM7RY">
-    <link rel="stylesheet" href="/static/css/masonry.css?v=642UM7RY">
-    <link rel="stylesheet" href="/static/css/components/video-view.css?v=642UM7RY">
+    <link rel="stylesheet" href="/static/css/style.css?v=6QA6CLTY">
+    <link rel="stylesheet" href="/static/css/masonry.css?v=6QA6CLTY">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?v=6QA6CLTY">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>
@@ -16,10 +16,10 @@
     <script type="module">
         const root = document.getElementById('app-root');
         try {
-            const response = await fetch('/static/templates/app_shell.html?v=642UM7RY');
+            const response = await fetch('/static/templates/app_shell.html?v=6QA6CLTY');
             if (!response.ok) throw new Error(`App shell request failed (${response.status})`);
             root.innerHTML = await response.text();
-            await import('/static/dist/app-642UM7RY.js');
+            await import('/static/dist/app-6QA6CLTY.js');
         } catch (error) {
             console.error('Failed to load the application shell', error);
             root.textContent = 'Failed to load the application. Please reload.';

--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pure Mania</title>
-    <link rel="stylesheet" href="/static/css/style.css?v=CUU5JEC7">
-    <link rel="stylesheet" href="/static/css/masonry.css?v=CUU5JEC7">
-    <link rel="stylesheet" href="/static/css/components/video-view.css?v=CUU5JEC7">
+    <link rel="stylesheet" href="/static/css/style.css?v=642UM7RY">
+    <link rel="stylesheet" href="/static/css/masonry.css?v=642UM7RY">
+    <link rel="stylesheet" href="/static/css/components/video-view.css?v=642UM7RY">
     <style>
     .cm-editor { border: 1px solid #ddd; }
     </style>
@@ -16,10 +16,10 @@
     <script type="module">
         const root = document.getElementById('app-root');
         try {
-            const response = await fetch('/static/templates/app_shell.html?v=CUU5JEC7');
+            const response = await fetch('/static/templates/app_shell.html?v=642UM7RY');
             if (!response.ok) throw new Error(`App shell request failed (${response.status})`);
             root.innerHTML = await response.text();
-            await import('/static/dist/app-CUU5JEC7.js');
+            await import('/static/dist/app-642UM7RY.js');
         } catch (error) {
             console.error('Failed to load the application shell', error);
             root.textContent = 'Failed to load the application. Please reload.';

--- a/static/js/upload-change-channel.js
+++ b/static/js/upload-change-channel.js
@@ -1,6 +1,10 @@
 const CHANNEL_NAME = 'puremania';
 const MESSAGE_TYPE = 'upload-changed';
 
+// Cross-tab messages are invalidation hints, never transfer state. IndexedDB
+// caches resume metadata and the server upload-session endpoint remains the
+// authoritative source for received bytes. This matches the SSE contract when
+// both PRs are integrated: either hint causes UploadPage to reload state.
 export class UploadChangeChannel {
     constructor(onChange, BroadcastChannelClass = globalThis.BroadcastChannel) {
         this.onChange = onChange;

--- a/static/js/upload-change-channel.js
+++ b/static/js/upload-change-channel.js
@@ -1,0 +1,26 @@
+const CHANNEL_NAME = 'puremania';
+const MESSAGE_TYPE = 'upload-changed';
+
+export class UploadChangeChannel {
+    constructor(onChange, BroadcastChannelClass = globalThis.BroadcastChannel) {
+        this.onChange = onChange;
+        this.channel = typeof BroadcastChannelClass === 'function'
+            ? new BroadcastChannelClass(CHANNEL_NAME)
+            : null;
+        this.channel?.addEventListener('message', event => {
+            if (event.data?.type !== MESSAGE_TYPE) return;
+            this.onChange({ uploadId: event.data.uploadId ?? null, remote: true });
+        });
+    }
+
+    notify(uploadId = null) {
+        const detail = { uploadId, remote: false };
+        this.onChange(detail);
+        this.channel?.postMessage({ type: MESSAGE_TYPE, uploadId });
+    }
+
+    close() {
+        this.channel?.close();
+        this.channel = null;
+    }
+}

--- a/static/js/upload-change-channel.test.mjs
+++ b/static/js/upload-change-channel.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { UploadChangeChannel } from './upload-change-channel.js';
+
+class FakeBroadcastChannel {
+    constructor(name) {
+        this.name = name;
+        this.messages = [];
+        this.listeners = new Map();
+        this.closed = false;
+    }
+
+    addEventListener(type, listener) { this.listeners.set(type, listener); }
+    postMessage(message) { this.messages.push(message); }
+    receive(message) { this.listeners.get('message')?.({ data: message }); }
+    close() { this.closed = true; }
+}
+
+test('notifies the current document and broadcasts the upload id', () => {
+    const changes = [];
+    const notifier = new UploadChangeChannel(detail => changes.push(detail), FakeBroadcastChannel);
+
+    notifier.notify('upload-1');
+
+    assert.equal(notifier.channel.name, 'puremania');
+    assert.deepEqual(changes, [{ uploadId: 'upload-1', remote: false }]);
+    assert.deepEqual(notifier.channel.messages, [{ type: 'upload-changed', uploadId: 'upload-1' }]);
+});
+
+test('accepts only typed changes from another tab', () => {
+    const changes = [];
+    const notifier = new UploadChangeChannel(detail => changes.push(detail), FakeBroadcastChannel);
+
+    notifier.channel.receive({ type: 'unrelated', uploadId: 'ignored' });
+    notifier.channel.receive({ type: 'upload-changed', uploadId: 'upload-2' });
+
+    assert.deepEqual(changes, [{ uploadId: 'upload-2', remote: true }]);
+});
+
+test('keeps same-document notifications when BroadcastChannel is unavailable', () => {
+    const changes = [];
+    const notifier = new UploadChangeChannel(detail => changes.push(detail), null);
+    notifier.notify('upload-3');
+
+    assert.deepEqual(changes, [{ uploadId: 'upload-3', remote: false }]);
+});

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -20,6 +20,8 @@ export class UploadPageHandler {
         this.jobs = [];
         this.refreshController = null;
         this.refreshRequested = false;
+        // Local EventTarget and BroadcastChannel notifications share one
+        // invalidation path; refresh() resolves authoritative server state.
         this.onJobsChanged = () => this.refresh();
         // Server events invalidate the view; REST/IndexedDB remain the source
         // of truth so coalesced or reconnected streams cannot render stale data.

--- a/static/js/upload-page.js
+++ b/static/js/upload-page.js
@@ -38,7 +38,7 @@ export class UploadPageHandler {
     enter() {
         if (this.active) return;
         this.active = true;
-        window.addEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
+        this.app.eventBus.addEventListener('upload-jobs-changed', this.onJobsChanged);
         this.app.eventBus.addEventListener('server:upload', this.onUploadState);
         this.app.eventBus.addEventListener('server:sync', this.onServerSync);
         document.querySelector('.breadcrumbs')?.style.setProperty('display', 'none');
@@ -51,7 +51,7 @@ export class UploadPageHandler {
         this.refreshController?.abort();
         this.refreshController = null;
         this.refreshRequested = false;
-        window.removeEventListener('puremania:upload-jobs-changed', this.onJobsChanged);
+        this.app.eventBus.removeEventListener('upload-jobs-changed', this.onJobsChanged);
         this.app.eventBus.removeEventListener('server:upload', this.onUploadState);
         this.app.eventBus.removeEventListener('server:sync', this.onServerSync);
         document.querySelector('.breadcrumbs')?.style.removeProperty('display');

--- a/static/js/uploader.js
+++ b/static/js/uploader.js
@@ -1,5 +1,7 @@
 // Resumable uploader: file bytes stay in the browser File object and each
 // request owns only one Blob slice. IndexedDB stores session metadata only.
+import { UploadChangeChannel } from './upload-change-channel.js';
+
 const CHUNK_SIZE = 8 * 1024 * 1024;
 const MIN_CONCURRENT_FILES = 2;
 const AIMD_DECISION_INTERVAL_MS = 1500;
@@ -188,6 +190,7 @@ export class Uploader {
         this._processingDrop = false;
         this.store = new UploadSessionStore();
         this.resumeRequest = null;
+        this.jobChanges = new UploadChangeChannel(detail => this.app.emit('upload-jobs-changed', detail));
         this.createResumeInputs();
     }
 
@@ -241,7 +244,7 @@ export class Uploader {
 
     isAbortError(error) { return error?.name === 'AbortError'; }
 
-    notifyJobsChanged() { window.dispatchEvent(new CustomEvent('puremania:upload-jobs-changed')); }
+    notifyJobsChanged(uploadId = null) { this.jobChanges.notify(uploadId); }
 
     showUploadDialog() { document.querySelector('.upload-input-files')?.click(); }
 
@@ -396,7 +399,7 @@ export class Uploader {
     async discardJob(key) {
         const record = await this.store.get(key);
         if (!record) return;
-        try { await fetch(record.url, { method: 'DELETE' }); } finally { await this.store.remove(key); this.notifyJobsChanged(); }
+        try { await fetch(record.url, { method: 'DELETE' }); } finally { await this.store.remove(key); this.notifyJobsChanged(record.id); }
     }
 
     async discardWrongRouteDuplicates(items, destination) {
@@ -440,7 +443,7 @@ export class Uploader {
             body: JSON.stringify({ path: destination, relativePath: item.relativePath, size: item.file.size, fingerprint })
         });
         const record = { key, id: created.uploadId, url: created.uploadURL, destination, relativePath: item.relativePath, size: item.file.size, fingerprint, updatedAt: Date.now() };
-        try { await this.store.put(record); this.notifyJobsChanged(); } catch (_) { /* upload itself must still work */ }
+        try { await this.store.put(record); this.notifyJobsChanged(record.id); } catch (_) { /* upload itself must still work */ }
         return { ...record, uploadedBytes: created.uploadedBytes || 0 };
     }
 
@@ -511,10 +514,10 @@ export class Uploader {
                     await pause((2 ** attempt) * 1000 + Math.floor(Math.random() * 250), session.signal);
                 }
             }
-            try { await this.store.put({ ...record, uploadedBytes: offset, updatedAt: Date.now() }); this.notifyJobsChanged(); } catch (_) { /* optional */ }
+            try { await this.store.put({ ...record, uploadedBytes: offset, updatedAt: Date.now() }); this.notifyJobsChanged(record.id); } catch (_) { /* optional */ }
         }
         await this.apiJSON(`${record.url}/complete`, { method: 'POST', signal: session.signal });
-        try { await this.store.remove(record.key); this.notifyJobsChanged(); } catch (_) { /* optional */ }
+        try { await this.store.remove(record.key); this.notifyJobsChanged(record.id); } catch (_) { /* optional */ }
         this.setFileProgress(record.key, item, item.file.size, 'Completed');
         this.progress.delete(record.key);
     }


### PR DESCRIPTION
## Dependency

This PR is stacked on #129 so SSE and BroadcastChannel use one tested invalidation path. After #129 merges, retarget this PR to `main`.

## What changed

- add a `puremania` BroadcastChannel for typed `upload-changed` invalidations
- include only the changed `uploadId` when session metadata changes
- route same-document, cross-tab, and server hints through the application EventTarget
- retain same-document behavior when BroadcastChannel is unavailable
- preserve #129's connection `sync` event so reconnect reconciliation follows the same authoritative reload path

## State ownership

- server REST state is authoritative
- IndexedDB caches resumable-session metadata
- BroadcastChannel and SSE are invalidation hints that trigger authoritative reloads

## Validation

- `go test ./...`
- `npm test` (42 passed with #129)
- `npm run build`
- `go build -o puremania .`
- `npm run test:e2e` (10 passed across Chromium desktop and mobile)
