### PR TITLE
fix: align keyboard shortcuts and focus handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,12 @@ These shortcuts are available anywhere in the file browser view.
 | Keybinding          | Action                               |
 | ------------------- | ------------------------------------ |
 | `Ctrl` + `f`        | Focus the search bar                 |
-| `Alt` + `←`         | Navigate to the parent directory     |
+| `Backspace` or `←`  | Navigate to the parent directory     |
 | `Delete`            | Delete selected file(s)              |
 | `F2`                | Rename the selected file or folder   |
-| `Ctrl` + `u`        | Show the upload dialog               |
-| `Ctrl` + `n`        | Create a new empty file              |
-| `Ctrl` + `Shift` + `n` | Create a new folder                  |
+| `u`                 | Show the upload dialog               |
+| `n` or `Alt` + `n`  | Create a new empty file              |
+| `Shift` + `n`       | Create a new folder                  |
 
 ### Search Bar: `cd` and `aria2c` Mode
 

--- a/e2e/keyboard.spec.js
+++ b/e2e/keyboard.spec.js
@@ -31,32 +31,42 @@ test.beforeEach(async () => {
     await resetStorage();
 });
 
-test('Ctrl+N creates a file', async ({ page }) => {
+test('N creates a file', async ({ page }) => {
     await openApp(page);
 
-    await page.keyboard.press('Control+N');
+    await page.keyboard.press('N');
     await completePrompt(page, 'Create File', 'keyboard-file.bin', 'Create');
 
     await expect(fileItem(page, 'keyboard-file.bin')).toBeVisible();
     await expect.poll(() => storagePathExists('keyboard-file.bin')).toBe(true);
 });
 
-test('Ctrl+Shift+N creates a folder', async ({ page }) => {
+test('Alt+N creates a file', async ({ page }) => {
     await openApp(page);
 
-    await page.keyboard.press('Control+Shift+N');
+    await page.keyboard.press('Alt+N');
+    await completePrompt(page, 'Create File', 'keyboard-alt-file.bin', 'Create');
+
+    await expect(fileItem(page, 'keyboard-alt-file.bin')).toBeVisible();
+    await expect.poll(() => storagePathExists('keyboard-alt-file.bin')).toBe(true);
+});
+
+test('Shift+N creates a folder', async ({ page }) => {
+    await openApp(page);
+
+    await page.keyboard.press('Shift+N');
     await completePrompt(page, 'Create Folder', 'keyboard-dir', 'Create');
 
     await expect(fileItem(page, 'keyboard-dir')).toBeVisible();
     await expect.poll(() => storagePathExists('keyboard-dir')).toBe(true);
 });
 
-test('Ctrl+U opens the native upload chooser', async ({ page }) => {
+test('U opens the native upload chooser', async ({ page }) => {
     await openApp(page);
 
     const [chooser] = await Promise.all([
         page.waitForEvent('filechooser'),
-        page.keyboard.press('Control+U'),
+        page.keyboard.press('U'),
     ]);
 
     expect(chooser.isMultiple()).toBe(true);
@@ -135,17 +145,44 @@ test('Delete requires selection and focus inside the file browser', async ({ pag
     await expect.poll(() => storagePathExists('delete-target.bin')).toBe(false);
 });
 
-test('Alt+Left navigates to the parent directory', async ({ page }) => {
+test('Backspace and ArrowLeft navigate to the parent directory', async ({ page }) => {
     await seedFiles({ 'parent/child/file.bin': 'nested' });
     await openApp(page);
     await openFileItem(page, 'parent');
     await openFileItem(page, 'child');
     await expect(page).toHaveURL(/\/parent\/child$/);
 
-    await page.keyboard.press('Alt+ArrowLeft');
+    await page.evaluate(() => {
+        const probe = event => {
+            if (event.key === 'ArrowLeft') {
+                globalThis.__arrowLeftPrevented = event.defaultPrevented;
+                document.removeEventListener('keydown', probe);
+            }
+        };
+        document.addEventListener('keydown', probe);
+    });
+    await page.keyboard.press('ArrowLeft');
 
     await expect(page).toHaveURL(/\/parent$/);
     await expect(page.locator('.breadcrumb-item[data-path="/parent"]')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => globalThis.__arrowLeftPrevented)).toBe(true);
+
+    await openFileItem(page, 'child');
+    await expect(page).toHaveURL(/\/parent\/child$/);
+
+    await page.evaluate(() => {
+        const probe = event => {
+            if (event.key === 'Backspace') {
+                globalThis.__backspacePrevented = event.defaultPrevented;
+                document.removeEventListener('keydown', probe);
+            }
+        };
+        document.addEventListener('keydown', probe);
+    });
+    await page.keyboard.press('Backspace');
+
+    await expect(page).toHaveURL(/\/parent$/);
+    await expect.poll(() => page.evaluate(() => globalThis.__backspacePrevented)).toBe(true);
 });
 
 test.describe('shortcut suppression', () => {

--- a/e2e/keyboard.spec.js
+++ b/e2e/keyboard.spec.js
@@ -118,6 +118,11 @@ test('Delete requires selection and focus inside the file browser', async ({ pag
     await expect(page.getByRole('dialog', { name: 'Delete Selected Items' })).toHaveCount(0);
 
     await item.click();
+    await expect(page.locator('.file-browser')).toBeFocused();
+    await page.keyboard.press('Delete');
+    await expect(page.getByRole('dialog', { name: 'Delete Selected Items' })).toBeVisible();
+    await page.getByRole('dialog', { name: 'Delete Selected Items' }).getByRole('button', { name: 'Cancel' }).click();
+
     await page.locator('.search-input').focus();
     await page.keyboard.press('Delete');
     await expect(item).toBeVisible();

--- a/static/js/events.js
+++ b/static/js/events.js
@@ -256,6 +256,10 @@ export class EventHandler {
             nextAnchor = path;
         }
         this.app.setSelection(nextSelection, nextAnchor);
+        // File cards are non-form containers, so a pointer click otherwise
+        // leaves focus on <body>. Keep keyboard actions scoped to the browser
+        // while allowing Delete to work immediately after selecting an item.
+        fileItem.closest('.file-browser')?.focus({ preventScroll: true });
     }
 
     handleFileDoubleClick(fileItem) {

--- a/static/js/events.js
+++ b/static/js/events.js
@@ -152,17 +152,32 @@ export class EventHandler {
         const target = e.target;
         if (target instanceof Element && target.closest('input, textarea, select, dialog, [contenteditable="true"], .cm-editor, .editor-modal')) return;
         const browserFocused = document.activeElement?.closest?.('.file-browser') || target?.closest?.('.file-browser');
+        const noModifiers = !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+        const altOnly = e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+        const shiftOnly = e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey;
         const keyActions = {
             'Delete': () => browserFocused && this.app.selectedFiles.size > 0 && this.app.api.deleteSelectedFiles(),
-            'ArrowLeft': () => e.altKey && this.app.navigateToParent(),
+            'Backspace': () => {
+                if (!noModifiers) return;
+                e.preventDefault();
+                this.app.navigateToParent();
+            },
+            'ArrowLeft': () => {
+                if (!noModifiers) return;
+                e.preventDefault();
+                this.app.navigateToParent();
+            },
             'f': () => e.ctrlKey && (e.preventDefault(), document.querySelector('.search-input')?.focus()),
             'n': () => {
-                if (e.ctrlKey) {
+                if (shiftOnly) {
                     e.preventDefault();
-                    e.shiftKey ? this.app.api.createNewFolder() : this.app.api.createNewFile();
+                    this.app.api.createNewFolder();
+                } else if (noModifiers || altOnly) {
+                    e.preventDefault();
+                    this.app.api.createNewFile();
                 }
             },
-            'u': () => e.ctrlKey && (e.preventDefault(), this.app.uploader.showUploadDialog()),
+            'u': () => noModifiers && (e.preventDefault(), this.app.uploader.showUploadDialog()),
             'F2': () => {
                 if (this.app.selectedFiles.size === 1) {
                     const path = Array.from(this.app.selectedFiles)[0];

--- a/static/templates/app_shell.html
+++ b/static/templates/app_shell.html
@@ -37,7 +37,7 @@
                 <button class="search-options" type="button" title="Search options" aria-label="Search options">⚙️</button>
             </div>
         </div>
-        <div class="file-browser"></div>
+        <div class="file-browser" tabindex="-1"></div>
     </div>
 </div>
 <div id="toast-container"></div>


### PR DESCRIPTION
## What changed

- make `.file-browser` programmatically focusable
- move focus into the file browser after selecting a file or folder
- keep Delete scoped to browser focus, so search fields and editors remain protected
- align global keyboard shortcuts with the simplified bindings: `N` / `Alt+N` for files, `Shift+N` for folders, `U` for uploads, and `Backspace` / `ArrowLeft` for the parent directory
- prevent parent-navigation shortcuts from triggering browser history as well
- update the README and browser E2E coverage for the new bindings and both parent-navigation keys

## Root cause

File cards are non-focusable `div` elements. Clicking one updated selection state but left `document.activeElement` on `<body>`. The Delete shortcut intentionally requires focus inside `.file-browser`, so it was ignored. F2 worked because it only checks the selection count.

The previous parent shortcut used `Alt+Left`, which could compete with the browser history action. The new parent bindings are unmodified `Backspace` and `ArrowLeft`, and both prevent the browser default action.

## Validation

- `go test ./...`
- `npm test` (37 passed)
- isolated Chromium desktop `npx playwright test e2e/keyboard.spec.js` (14 passed)
- isolated Chromium desktop/mobile keyboard suite (28 passed)
