### PR TITLE
fix: use patched Go 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.13'
           cache: true
           cache-dependency-path: '**/go.sum'
 
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.13'
           cache: true
           cache-dependency-path: '**/go.sum'
 
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.13'
           cache: true
           cache-dependency-path: '**/go.sum'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.13-bookworm AS builder
 
 WORKDIR /src
 
@@ -34,7 +34,7 @@ RUN apt-get update \
         media-types \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --uid 1000 --home-dir /home/puremania --create-home --shell /usr/bin/nologin puremania \
+RUN useradd --system --uid 1000 --home-dir /home/puremania --create-home --shell /usr/sbin/nologin puremania \
     && mkdir -p /app /data \
     && chown -R puremania:puremania /app /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
         media-types \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --uid 1000 --home-dir /home/puremania --create-home --shell /usr/sbin/nologin puremania \
+RUN useradd --system --uid 1000 --home-dir /home/puremania --create-home --shell /usr/bin/nologin puremania \
     && mkdir -p /app /data \
     && chown -R puremania:puremania /app /data
 


### PR DESCRIPTION
## Summary
- pin GitHub Actions Go version to 1.25.13
- pin the Docker builder image to Go 1.25.13

## Why
`govulncheck` currently fails on Go 1.25.12 with five reachable standard-library vulnerabilities (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026). All are fixed in Go 1.25.13.

This keeps the fix scoped to the vulnerable Go patch release without changing application code or weakening `govulncheck`.